### PR TITLE
Clean up a bunch of missing locals/globals and type mismatches; also drop a vscode config configured for proper linting and editing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,31 @@
+{
+   "editor.insertSpaces": true,
+   "editor.tabSize": 3,
+   "Lua.diagnostics.globals": [
+      "commands",
+      "defines",
+      "data",
+      "game",
+      "global",
+      "localised_print",
+      "rcon",
+      "remote",
+      "rendering",
+      "script",
+      "settings",
+      "players",
+      "printout",
+      "get_selected_ent",
+      "direction_lookup",
+      "cursor_highlight",
+      "sync_build_cursor_graphics",
+      "get_direction_of_that_from_this",
+      "clear_obstacles_in_rectangle",
+      "ENT_TYPES_YOU_CAN_BUILD_OVER"
+   ],
+   "Lua.diagnostics.disable": [
+      "lowercase-global",
+      "deprecated",
+      "need-check-nil"
+   ],
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Welcome to Factorio Access BETA!
 
-This is the BETA VERSION for an accessibility mod for the popular game Factorio. The goal of this mod is to make the game completely accessible to the blind and visually impaired. This beta version is the current main repository for the mod, while the original repository is on hold.
+This is the BETA VERSION for an accessibility mod for the popular game Factorio. The goal of this mod is to make the game completely accessible to the blind and visually impaired. This beta version is the current main repository for the mod, while the original repository for the alpha version is on hold. This mod is an unofficial Factorio project by volunteers.
 
 This "read me" file covers the basics of the mod, which include the installation guide, the mod controls, and links to other information sources.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,15 @@ This is the BETA VERSION for an accessibility mod for the popular game Factorio.
 
 This "read me" file covers the basics of the mod, which include the installation guide, the mod controls, and links to other information sources.
 
+# More info at the wiki
+
+For information about the mod and the game, please check out our own [Factorio Access Wiki](https://github.com/Factorio-Access/FactorioAccess/wiki) being written by the developers.
+
+Factorio also has an [official wiki](https://wiki.factorio.com/).
+
+# Frequently Asked Questions
+Please check the [Factorio Access Wiki main page](https://github.com/Factorio-Access/FactorioAccess/wiki) for frequently asked questions section.
+
 # Installing Factorio
 The game can be purchased from Factorio.com or from Steam. We recommend installing it using ONLY one of the three options below.
 
@@ -76,15 +85,6 @@ To install a mod release, follow the instructions below:
 4. If you want to use a virtual python environment, or an executable, run build_main.py. If not, run pip to install requirements.txt by:  "pip install -r requirements.txt"
 5. Run the executable or main.py
 6. If it complains it can't find your Factorio installation then add the path to the Factorio executable as an argument when launching.
-
-# More info at the wiki
-
-For information about the mod and the game, please check out our own [Factorio Access Wiki](https://github.com/Factorio-Access/FactorioAccess/wiki) being written by the developers.
-
-Factorio also has an [official wiki](https://wiki.factorio.com/).
-
-# Frequently Asked Questions
-Please check the [Factorio Access Wiki main page](https://github.com/Factorio-Access/FactorioAccess/wiki) for frequently asked questions section.
 
 # Factorio Access Controls
 

--- a/circuit-networks.lua
+++ b/circuit-networks.lua
@@ -1,5 +1,8 @@
 --Here: Functions relating to circuit networks, virtual signals, wiring and unwiring buildings, and the such.
 --Does not include event handlers directly, but can have functions called by them.
+local localising = require('localising')
+local util = require('util')
+
 local dcb = defines.control_behavior
 
 function drag_wire_and_read(pindex)
@@ -84,7 +87,8 @@ function drag_wire_and_read(pindex)
    else
       p.play_sound{path = "utility/cannot_build"}
    end
-   players[pindex].last_wire_ent = c_ent
+   -- used to be c_int, but that's an undefined global, which is nil.
+   players[pindex].last_wire_ent = nil
 end
 
 --*** later: test ent.circuit_connection_definitions
@@ -1385,8 +1389,8 @@ function build_signal_selector(pindex)
       group_index = 1, 
       group_names = item_group_names, 
       signals = {},
-      ent = ent,
-      editing_first_slot = nil
+      ent = nil,
+      editing_first_slot = nil,
    }
    --Populate signal groups 
    local items = get_iterable_array(game.item_prototypes)
@@ -1461,7 +1465,7 @@ end
 
 --For an enabled condition, updates the relevant signal from the signal selector. For a constant combinator, the selected signal gets added.
 function apply_selected_signal_to_enabled_condition(pindex, ent, first)
-   local start_phrase = start_phrase_in or ""
+   local start_phrase = ""
    local prototype, signal_type = get_selected_signal_slot_with_type(pindex)
    if prototype == nil or prototype.valid == false then
       game.get_player(pindex).play_sound{path = "utility/cannot_build"}

--- a/equipment-and-combat.lua
+++ b/equipment-and-combat.lua
@@ -1,5 +1,6 @@
 --Here: functions relating to combat, repair packs 
 --Does not include event handlers, guns and equipment, repair work (but maybe it could?)
+local util = require('util')
 
 --Tries to equip a stack. For now called only for a stack in hand when the only the inventory is open.
 function equip_it(stack,pindex)

--- a/localising.lua
+++ b/localising.lua
@@ -1,13 +1,17 @@
 --Here: localisation functions, including event handlers
 local localising = {}
 --Returns the localised name of an object as a string. Used for ents and items and fluids
+---@return string
 function localising.get(object,pindex)
+      -- Everything, everything uses this function without checking the return
+      -- values. Use really annoying strings to make it very clear there's a
+      -- bug.
    if pindex == nil then
       game.print("localising: pindex is nil error")
-      return nil
+      return "NOT LOCALIZED!"
    end
    if object == nil then
-      return nil
+      return "LOCALIZED OBJECT IS NIL!"
    end
    if object.valid and string.sub(object.object_name,-9) ~= "Prototype" then
       object = object.prototype

--- a/rails-and-trains.lua
+++ b/rails-and-trains.lua
@@ -1,5 +1,6 @@
 --Here: Functions relating to rails, trains, signals, other vehicles
 --Does not include event handlers
+local util = require('util')
 
 dirs = defines.direction
 
@@ -881,7 +882,7 @@ function identify_rail_segment_end_object(rail, dir_ahead, accept_only_forward, 
    
    if rail == nil or rail.valid == false then
       --Error
-      result_entity = segment_last_rail
+      result_entity = nil
       result_entity_label = "missing rail"
       return result_entity, result_entity_label, result_extra, result_is_forward
    end
@@ -4246,6 +4247,8 @@ end
 
 function nearby_train_schedule_read_this_stop(train_stop)
    local result = "Reading parked train: "
+   local found_any = false
+
    --Locate the nearby train
    local train = train_stop.get_stopped_train()
    if train == nil or not train.valid then
@@ -4268,7 +4271,6 @@ function nearby_train_schedule_read_this_stop(train_stop)
       return result
    else
       local records = schedule.records
-      local found_any = false
       result = "Reading parked train, "
       for i,r in ipairs(records) do
          if r.station == train_stop.backer_name then


### PR DESCRIPTION
I started looking into circuits.  In vscode.  This was, a "mistake"...so here's a bunch of small local cleanups.  Rather than a bunch of individual prs, for each of these, I put it into one. Specifically:

- In lua undefined globals are nil.  Some come from control.lua.  In a few places here where it was obvious that they didn't I replaced it with nil, instead.
- Proper importing of Lua modules is `local x = require('x')`.  Require calls run only once.  Missing the word local will create  a project-global variable, not a file-global variable.  In particular, it's not out of the question that that could even hit other mods, though presumably Factorio is smart enough to run them in different environments.
- localisation decided to return nil instead of a string.  In Lua that's going to stringify as "nil".  Instead, let's return an annoying reason why so that people will fix these, and at least know that it's a localisation problem and not an actually missing value.
- Lots of places are using nil instead of 0.  That's kinda a problem.  In particular you cant actually do math on them but the code does anyway.  This probably isn't coming up because those branches aren't being reached.  Whether they are reachable is another question beyond the scope of this pr.

The big other one I spotted that I left alone here is a pattern like this:

```

result = "foo bar baz qux"
return result
```

Instead of a simple return.  That should also be fixed but while this code is fragile, it didn't seem worth chasing at this time.

Testing is the mod loads.  I'll make a point of playing on my fork.  Hopefully it's easy (in a sense) to review these; the changes are each individually local.  Waiting until I've done 5-10 hours of playing to get full coverage seemed worse than submitting now.