### PR TITLE
Introduce an abstraction to help with circular lists of options, and …

### DIFF
--- a/circuit-networks.lua
+++ b/circuit-networks.lua
@@ -1,9 +1,28 @@
 --Here: Functions relating to circuit networks, virtual signals, wiring and unwiring buildings, and the such.
 --Does not include event handlers directly, but can have functions called by them.
+local circular = require('ds/circular-options-list')
 local localising = require('localising')
 local util = require('util')
 
 local dcb = defines.control_behavior
+
+-- Later, we will move this list to somewhere more convenient.  Currently, this
+-- is demonstrational, and we aren't rolling out a full descriptor-based system
+-- at this time.  Instead, we just handle inserters this way.
+local INSERTER_READ_MODES = circular.kv_list({
+   -- (circuit_read_hand_contents, circuit_read_hand_mode) to a set of labels
+   -- for each.
+   { { false,  circular.ANY }, {
+      label = "None",
+      disabled = true,
+   } },
+   { { true, dcb.inserter.hand_read_mode.hold  }, {
+      label = "Reading held items",
+   }},
+   {{ true, dcb.inserter.hand_read_mode.pulse }, {
+      label = "pulsing passing items"
+   } },
+}, circular.tuples)
 
 function drag_wire_and_read(pindex)
    --Start/end dragging wire 
@@ -313,13 +332,8 @@ function get_circuit_read_mode_name(ent)
    local result = "None"
    local control = ent.get_control_behavior()
    if ent.type == "inserter" then
-      if control.circuit_read_hand_contents == true then
-         if control.circuit_hand_read_mode == dcb.inserter.hand_read_mode.hold then
-            result = "Reading held items" 
-         elseif control.circuit_hand_read_mode == dcb.inserter.hand_read_mode.pulse then
-            result = "pulsing passing items" 
-         end
-      end
+      local cur = circular.current(INSERTER_READ_MODES, { control.circuit_read_hand_contents, control.circuit_hand_read_mode })
+      result = cur.value.label
    elseif ent.type == "transport-belt" then
       if control.read_contents == true then
          if control.read_contents_mode == dcb.transport_belt.content_read_mode.hold then
@@ -366,18 +380,13 @@ function toggle_circuit_read_mode(ent)
    local control = ent.get_control_behavior()
    if ent.type == "inserter" then
       changed = true
-      if control.circuit_read_hand_contents == false then
-         control.circuit_read_hand_contents = true
-         control.circuit_hand_read_mode = dcb.inserter.hand_read_mode.hold
-         result = "Reading held items" 
-      elseif control.circuit_hand_read_mode == dcb.inserter.hand_read_mode.hold then
-         control.circuit_read_hand_contents = true
-         control.circuit_hand_read_mode = dcb.inserter.hand_read_mode.pulse
-         result = "pulsing passing items"
-      else --if control.circuit_hand_read_mode == dcb.inserter.hand_read_mode.pulse then
-         control.circuit_read_hand_contents = false
-         result = "None"
+      local key = { control.circuit_read_hand_contents, control.circuit_hand_read_mode }
+      local new  = circular.next(INSERTER_READ_MODES, key)
+      control.circuit_read_hand_contents = new.key[1]
+      if not new.value.disabled then
+         control.circuit_hand_read_mode = new.key[2]
       end
+      result = new.value.label
    elseif ent.type == "transport-belt" then 
       changed = true
       if control.read_contents == false then

--- a/ds/circular-options-list.lua
+++ b/ds/circular-options-list.lua
@@ -1,0 +1,159 @@
+--[[
+A circular, static list of options.
+
+This solves the problem where there's a property, it's got a few values, and
+each of those values has a label or something.  The property could change at any
+time out from under the mod, and it needs to be tracked.
+
+Lists take the form:
+
+```
+{
+   entries = {
+      { key = defines.whatever, value = { label = "foo" } }
+      ... and so on
+   },
+   options = {
+      comparer = func, -- defaults to ==, see below.
+   },
+}
+```
+
+Which looks like a dictionary because it is, but a poor man's ordered one.  The
+functions in this file take such lists, and can answer the question what is
+previous/current/next, based on a fed-in value.
+
+sometimes, it is the case that one wishes to use a more complex key. For
+example, a tuple of items.  In this case, one may override the comparison by
+setting options.comparer to a function taking two arguments, and returning true
+if and only if they are equal (and otherwise false).  This module provides one
+such helper, `tuples`, which is useful in the case of state machines whose state
+is more than one variable.  For an example of this, see circuit-networks.lua,
+and also see the comments on tuples for additional information.
+
+A helper, kv_list, can be used like this:
+
+```
+kv_list{{ key1, value1 }, { key2, value2 }, ... }
+```
+
+To build these inline without dealing with the verbose syntax.  To do this with
+a comparer:
+
+```
+kv_list({...}, comparer)
+```
+
+Note that during a single Lua call--a single event handler, in other words--the
+mod "owns" the state and fields will only change because the mod did something.
+
+This module does *not* handle the case of duplicate keys (so, no inventories;
+the user won't be able to get past the second instance) and it does *not* handle
+the case of missing values (it will hard crash intentionally).  It does handle
+appending and reordering keys.  The point is things like circuit networks where
+there are some fixed values and a property, not more complex things.  By the
+fact that it doesn't handle missing values, it doesn't handle empty lists either
+(no values are  found in an empty list).
+
+Operations are all O(N).
+]]
+local math_helpers = require('math-helpers')
+
+local _m = {}
+
+_m.ANY = {}
+
+--[[
+If the keys in this list need to be tuples, this comparer will allow for that by
+comparing field by field in an array. For example, { true, "value"}.
+
+A magical constant `ANY` exposed in this module will match any value. Consider
+this list of circuit network states:
+
+```
+{ false, ANY }
+{ true, holding }
+{ true, pulsing }
+```
+
+If the object is off (the first state) then the second field doesn't matter, and
+we wish to stil move to the second entry.  `ANY` is useful in this case.  The
+requirement for safe usage is that any use of `ANY` is such that the other
+fields of the tuple uniquely identify the state. For example:
+
+```
+{ 1, ANY }
+{ 1, 2}
+```
+
+Is a list with duplicates because `{ 1, ANY }` matches `{ 1, 2 }`.
+]]
+
+function _m.tuples(a, b)
+   if #a ~= #b then return false end
+   for i = 1, #a do
+      if a[i] ~= b[i] and a[i] ~= _m.ANY and b[i] ~= _m.ANY then return false end
+   end
+
+   return true
+end
+
+function _m.kv_list(list, comparer)
+   vals = {}
+   for i = 1, #list do
+      vals[i] = { key = list[i][1], value = list[i][2] }
+   end
+   return {
+      values = vals,
+      options = { comparer = comparer }
+   }
+end
+
+function find_key_index_or_die(list, key)
+   local cmp = list.options.comparer or rawequal
+   for i = 1, #list.values do
+      if cmp(list.values[i].key, key) then return i end
+   end
+
+   error("Key " .. serpent.block(key) .. " not in this list" .. serpent.block(list))
+end
+
+--[[
+Returns the current item, as a table with fields key and value.  For
+convenience, field wrapped is set to false (see prev/next for what that's for)
+
+This is basically lookup, but so named because the key is the current
+item--you're owning the place the index is stored, not this module, but it is
+still an index.
+]]
+function _m.current(list, key)
+   local i = find_key_index_or_die(list, key)
+   return { key = list.values[i].key, value = list.values[i].value, wrapped = false }
+end
+
+--[[
+next and prev are the movement functions, which move forward by one element or
+backward by one element, respectively.  They return a table with fields key,
+value, and wrapped, where key and value match the keys and values in the list,
+and wrapped is true if this operation wrapped around to the other end of the
+list.
+]]
+
+function _m.next(list, current_key)
+   local i = find_key_index_or_die(list, current_key)
+   local next_i = math_helpers.mod1(i + 1, #list.values)
+   -- <= because lists of 1 item always wrap back to the same index.
+   local wrapped = next_i <= i
+   print(next_i)
+   return { key = list.values[next_i].key, value = list.values[next_i].value, wrapped = wrapped }
+end
+
+function _m.prev(list, current_key)
+   local i = find_key_index_or_die(list, current_key)
+   local prev_i = math_helpers.mod1(i - 1, #list.values)
+   -- >= because lists of 1 item always wrap back to the same index.
+   local wrapped = prev_i >= i
+   return { key = list.values[prev_i].key, value = list.values[prev_i].value, wrapped = wrapped }
+end
+
+return _m

--- a/math-helpers.lua
+++ b/math-helpers.lua
@@ -1,0 +1,25 @@
+--[[
+Additional mathematical helpers on top of Lua's built-in math library.
+
+These are pure functions: no side effects, and return the same value out for the
+same values in.
+]]
+
+local _m = {}
+
+--[[
+Computes a 1-based modulus.
+
+In most languages, with 0-based indices, a useful way to "go in circles" such
+that always increasing an index iterates over an array over and over, is to do
+`i % len(array))` which, as i increments, will repeat from 0 to len(array) over
+and over.  In Lua, we have one-based indices.  mod1 is the same operation as %
+in a zero-based language, but offset so that it works with lua tables.
+
+E.g. given 1, 2, 3, 4, 5,  6, and mod1(i, 3), you get 1, 2, 3, 1, 2, 3
+]]
+function _m.mod1(index, length)
+   return ((index - 1) % length) + 1
+end
+
+return _m


### PR DESCRIPTION
A problem which occurs frequently in this mod is a set of statements whose branches are used to figure out what the current and/or next value is, written by hand and scattered all over the code.  Instead, we may introduce an abstraction called a circular list.  In this PR, I demonstrate the concept by showing how one might apply it to inserter hand read modes.  Specifically, we:

- Introduce a small math helper file to contain mod1, a function which makes circular iteration over arrays very easy in Lua.  There's other candidates to move there; we will later.
- Introduce a folder called ds, short for data structures, where code which doesn't really depend much on Factorio and is more about the algorithms may live (in the future graphs, trees, whatever).
- Introduce a "circular options list", which takes a list of things and a key and tells you which one you're on, and what comes before/after, and
- Use this to replace the inserter read mode logic with a declarative set of labels in exactly one place, rather than all over.

Start at circuit-networks.lua to get the point, as the data structure itself is a lot of reading,.  The point is to be a lot of reading encapsulated behind the abstraction and not much outside it, so everyone can just use it.  Note that this isn't the finished version, because really most things circuit network related have a very few specific sets of things.  Once applied everywhere this pattern can then be simplified further.  Notably, much of circuit networks are two fields where one is on/off and effectively 3 states instead of 4, and there is no reason in the long term that we can't move one more step along this path and make it really good.  For now, however, small steps and the like.

There's two ways to use it. The one we don't show here (due to, so far, the lack of need) is primitive keys.  For circuit networks we instead introduce support for custom comparers, and introduce one for tuples--small arrays where the elements are different types (in Lua everything including arrays is a table etc. Tuple at least distinguishes that its small, keys are ignored, and the types vary).

The one subtlety is that circuit networks have 3 states in 4 variables, such that when a boolean flag is off the second variable should be ignored.  We solve that by introducing a `ANY` constant, which is the equivalent of `*` in grep.  As long as there's no intersecting patterns, we get to use it to represent 4-but-3 state state machines. Cut out of the code, we make a menu with these 3 keys:

```
{ false,  circular.ANY }
{ true, dcb.inserter.hand_read_mode.hold  }
{ true, dcb.inserter.hand_read_mode.pulse }
```

Where the first covers all the off states.