### PR TITLE
set up stylua and a GitHub action to complain at prs who get it wrong

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+on:
+  push: {}
+  pull_request: {}
+
+jobs:
+  check-format:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: 'stylua --check'
+      uses: JohnnyMorganz/stylua-action@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        version: latest # NOTE: we recommend pinning to a specific version in case of formatting changes
+        # CLI arguments
+        args: --check .

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,15 +1,12 @@
 {
-	// See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-	// Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
-	// List of extensions which should be recommended for users of this workspace.
-	"recommendations": [
-		"justarandomgeek.factoriomod-debug",
-		"sumneko.lua"
-		
-	],
-	// List of extensions recommended by VS Code that should not be recommended for users of this workspace.
-	"unwantedRecommendations": [
-		
-	]
+   // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+   // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+   // List of extensions which should be recommended for users of this workspace.
+   "recommendations": [
+      "justarandomgeek.factoriomod-debug",
+      "sumneko.lua",
+      "JohnnyMorganz.stylua",
+   ],
+   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+   "unwantedRecommendations": []
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,10 @@
          "request": "launch",
          "name": "Factorio Mod Debug",
          "modsPath": "${fileWorkspaceFolder}\\..\\",
-         "factorioArgs": ["--load-game", "test.zip"]
+         "factorioArgs": [
+            "--load-game",
+            "test.zip"
+         ]
       },
       {
          "type": "factoriomod",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,4 +22,7 @@
    ],
    "Lua.workspace.checkThirdParty": "ApplyInMemory",
    "Lua.runtime.version": "Lua 5.2",
+   "[lua]": {
+      "editor.defaultFormatter": "JohnnyMorganz.stylua"
+   }
 }

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,3 @@
+indent_type = "Spaces"
+indent_width = 3
+collapse_simple_statement = "ConditionalOnly"


### PR DESCRIPTION
The gh action will send one (or more) e-mails based on settings.  The most useful configuration is to configure it to only send once when the pas/fail state changes.

The vscode files configure the default formatter for Lua and recommend JohnnyMorganz.stylua.

The big lua commit works like this: when we're ready to merge we drop the formatting commit, rebase onto nexst-update or w/e, and then rerun stylua 3 or so times (it reaches stability but as you can see modified 15kloc).  Honestly I'll probably squash this one for a change, they belong in one commit but this is broken up so that we can deal with the conflicts.