### PR TITLE
Fix getting inventory counts of rail in kruise kontrol monitoring

### DIFF
--- a/scripts/kruise-kontrol-wrapper.lua
+++ b/scripts/kruise-kontrol-wrapper.lua
@@ -163,7 +163,20 @@ function mod.status_update(pindex)
          local ghost_count = #ghosts
          local ignore_count = 0
          for i, ghost in ipairs(ghosts) do
-            if p.get_main_inventory().get_item_count(ghost.ghost_name) == 0 then
+            local amount = 1
+            local inv_query = ghost.ghost_name
+
+            -- Rails are special: curved rails aren't crafted but cost 4 rail;
+            -- there is no straight-rail as an item.
+            if ghost.ghost_name == "curved-rail" then
+               inv_query = "rail"
+               amount = 4
+            elseif ghost.ghost_name == "straight-rail" then
+               amount = 1 -- for clarity.
+               inv_query = "rail"
+            end
+
+            if p.get_main_inventory().get_item_count(inv_query) < amount then
                ignore_count = ignore_count + 1
             else
                --Still going to build it


### PR DESCRIPTION
There is no straight-rail or curved-rail item, only entities.  Ghosts tell us which entity they are, but the actual logic has to translate them to rail and an appropriate count (1 for straight, 4 for curved).  This means whenever a rail ghost exists, KK would crash.

The fix is simple: instead of always using 1 use an amount variable, and translate straight-rail and curved-rail before checking whether the player has enough to build it.

Can't say it's well tested because the KK monitoring stuff is too buggy and surprising and whatnot but it's isolated changes that shouldn't impact anything else and the old behavior was a crash so I'm happy enough to call it good if you are.

I am going to bet this can be done generically, if it comes up again I can look into it, but I think it's just rails.