### PR TITLE
Add support for reading the consumption stats, and clean up the code while there

### DIFF
--- a/scripts/fa-utils.lua
+++ b/scripts/fa-utils.lua
@@ -915,4 +915,20 @@ function mod.player_was_still_for_1_second(pindex)
    end
 end
 
+-- Given a list of items which may be stringified, concatenate them all together
+-- with a space between, efficiently.
+mod.spacecat = function(...)
+   local tab = table.pack(...)
+   local will_cat = {}
+
+   for i = 1, tab.n do
+      local ent = tab[i]
+      local stringified = tostring(ent)
+      if stringified == nil then stringified = "NIL!" end
+      table.insert(will_cat, stringified)
+   end
+
+   return table.concat(will_cat, " ")
+end
+
 return mod


### PR DESCRIPTION
We introduce fa_utils.spacecat, which takes any number of stringifiable things and converts them into a space-separated list.  This is more efficient and easier to read than .. (if Lua knows ahead of time it may avoid intermediate string building), and can get rid of the hard to follow result variables. Then we use this to easily tweak wording in selection_item_production_stats_info, to be more brief and to add the consumption (output in mod language) stats.

Note a couple things.  First the output code and input code are the same by one boolean, thus a quick local closure.  After that and the wording tweak it then becomes evident that we need internal_name only in two spots, so we get to kill that variable.  In context we have enough to not use super long variable names, so we get to also simplify some of those.

I cannot for the life of me figure out how to reach the second of the two recipe fluid branches.  I hand tested all the other cases.  Because we only check hand, inventory, and crafting menu, there's no way to get my hand on a fluid recipe which could trigger reading the second index because the first product must be either an item or a fluid and we check for both--except I think that's supposed to be else if as well too.  Unless recipes can output something else, maybe?