### PR TITLE
Fix cursor skipping, and find out why things about tiles get weird

### DIFF
--- a/scripts/building-tools.lua
+++ b/scripts/building-tools.lua
@@ -305,7 +305,7 @@ function mod.build_item_in_hand(pindex, free_place_straight_rail)
    end
 
    --Update cursor highlight (end)
-   local ent = get_selected_ent(pindex)
+   local ent = get_selected_ent_deprecated(pindex)
    if ent and ent.valid then
       fa_graphics.draw_cursor_highlight(pindex, ent, nil)
    else
@@ -367,7 +367,7 @@ function mod.rotate_building_info_read(event, forward)
    local mult = 1
    if forward == false then mult = -1 end
    if players[pindex].in_menu == false or players[pindex].menu == "blueprint_menu" then
-      local ent = get_selected_ent(pindex)
+      local ent = get_selected_ent_deprecated(pindex)
       local stack = game.get_player(pindex).cursor_stack
       local build_dir = players[pindex].building_direction
       if stack and stack.valid_for_read and stack.valid and stack.prototype.place_result ~= nil then
@@ -482,7 +482,7 @@ function mod.nudge_key(direction, event)
    local pindex = event.player_index
    local p = game.get_player(pindex)
    if not check_for_player(pindex) or players[pindex].menu == "prompt" then return end
-   local ent = get_selected_ent(pindex)
+   local ent = get_selected_ent_deprecated(pindex)
    if ent and ent.valid then
       if ent.force == game.get_player(pindex).force then
          local old_pos = ent.position

--- a/scripts/fa-info.lua
+++ b/scripts/fa-info.lua
@@ -1204,7 +1204,7 @@ end
 
 --Report the status of the selected entity as well as additional dynamic info depending on the entity type
 function mod.read_selected_entity_status(pindex)
-   local ent = get_selected_ent(pindex)
+   local ent = get_selected_ent_deprecated(pindex)
    if not ent then return end
    local stack = game.get_player(pindex).cursor_stack
    if players[pindex].in_menu then return end

--- a/scripts/quickbar.lua
+++ b/scripts/quickbar.lua
@@ -67,7 +67,7 @@ function mod.set_quick_bar_slot(index, pindex)
    local page = game.get_player(pindex).get_active_quick_bar_page(1) - 1
    local stack_cur = game.get_player(pindex).cursor_stack
    local stack_inv = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
-   local ent = get_selected_ent(pindex)
+   local ent = get_selected_ent_deprecated(pindex)
    if stack_cur and stack_cur.valid_for_read and stack_cur.valid == true then
       game.get_player(pindex).set_quick_bar_slot(index + 10 * page, stack_cur)
       printout("Quickbar assigned " .. index .. " " .. fa_localising.get(stack_cur, pindex), pindex)

--- a/scripts/spidertron.lua
+++ b/scripts/spidertron.lua
@@ -8,7 +8,7 @@ function mod.run_spider_menu(menu_index, pindex, spiderin, clicked, other_input)
    local spider
    local remote = game.get_player(pindex).cursor_stack
    local other = other_input or -1
-   local cursortarget = get_selected_ent(pindex)
+   local cursortarget = get_selected_ent_deprecated(pindex)
    local spidertron = game.get_player(pindex).cursor_stack.connected_entity
    if spiderin ~= nil then spider = spiderin end
    if index == 0 then

--- a/scripts/trains.lua
+++ b/scripts/trains.lua
@@ -417,7 +417,7 @@ function mod.run_train_menu(menu_index, pindex, clicked, other_input)
    local index = menu_index
    local other = other_input or -1
    local locomotive = nil
-   local ent = get_selected_ent(pindex)
+   local ent = get_selected_ent_deprecated(pindex)
    if game.get_player(pindex).vehicle ~= nil and game.get_player(pindex).vehicle.name == "locomotive" then
       locomotive = game.get_player(pindex).vehicle
       players[pindex].train_menu.locomotive = locomotive

--- a/scripts/travel-tools.lua
+++ b/scripts/travel-tools.lua
@@ -442,7 +442,7 @@ function mod.fast_travel_menu_click(pindex)
       end
 
       --Update cursor highlight
-      local ent = get_selected_ent(pindex)
+      local ent = get_selected_ent_deprecated(pindex)
       if ent and ent.valid then
          fa_graphics.draw_cursor_highlight(pindex, ent, nil)
       else

--- a/scripts/worker-robots.lua
+++ b/scripts/worker-robots.lua
@@ -959,7 +959,7 @@ function mod.logistics_info_key_handler(pindex)
          if prototype then mod.player_logistic_request_read(prototype, pindex, true) end
       else
          --Logistic chest in front
-         local ent = get_selected_ent(pindex)
+         local ent = get_selected_ent_deprecated(pindex)
          if mod.can_make_logistic_requests(ent) then
             mod.read_entity_requests_summary(ent, pindex)
             return
@@ -1914,7 +1914,7 @@ end
 function mod.run_roboport_menu(menu_index, pindex, clicked)
    local index = menu_index
    local port = nil
-   local ent = get_selected_ent(pindex)
+   local ent = get_selected_ent_deprecated(pindex)
    if game.get_player(pindex).opened ~= nil and game.get_player(pindex).opened.name == "roboport" then
       port = game.get_player(pindex).opened
       players[pindex].roboport_menu.port = port


### PR DESCRIPTION
TLDR: deprecate get_selected_ent, rename it to get_selected_ent_deprecated for lack of something better, if I am reviewing a PR and see it I will hard veto with prejudice.  Use iterate_selected_ents for iteration functionality that filters out the player. Reorganize cursor_skip_iteration to be slightly less complicated. See below for the long version.

The cursor decided to be amusing and started always skipping by exactly one if starting on a tile with an entity.  I don't actually know when this broke.  It happened somewhere between cursor rolling (before the rename) and the tip of next-update, and git blame hates us because of the reformatting commit.  The source of the bug goes back basically forever, and a dose of luck caused us not to hit it.

That lead to a rabbit hole.  get_selected_ent was not a getter, it was also silently trying to manage a cache.  The idea was to get entities on a tile while ignoring the current player, but it has a number of surprising edge cases for 10 lines and even a discussion on Discord between all 3 of us couldn't get to the bottom of it.  We know that the mutation piece is broken because commenting out the table.remove is what "fixed" the issue (this pr being the real fix).

So, we kill it with prejudice.  Instead, we can implement a proper Lua iterator that isn't stateful, which is O(N) as opposed to the O(N^2) which would be required by a function like this that wishes to ignore players, , and then we can make things less error-prone by having that iterator skip invalid entities (in general you want to handle that low down; a higher level check does no harm,but they are easy to miss).

Put another way:

```
for ent in iterate_selected_ents(pindex) do
-- Ent is valid for the duration of this function/whatever,
-- long as you don't return to Factorio,
-- and not the player who called it.
end
```

Now works, and does what the old functions were actually doing, except you can do it repeatedly without refreshes.

Lastly, we refactor cursor_skip_iteration slightly by pulling common code out to a closure compute_current.  In addition to the problems above, it was also having issues with start vs current mismatching; I did not debug that because I'd fixed it at that point.  That causes an immediate stop.  By using compute_current for both start and current, we guarantee they run the exact same check and start equal.  I will not swear they can be equal but on the wrong entity, but I do believe this to be impossible. That function deserves more cleanup however.

Because we are gearing up for a release, we cannot address all of the cases, and in fact still mix cursor skipping code with it.  To deal with that, we fold refreshing the tile cache into compute_current.  But the following two concerns in general remain:

- Refreshing the tile hits Factorio's surface API multiple times for small searches.  That's probably inefficient.
- I'd be willing to bet some of the scanner crashes are related in some way. Pretty much anything working with tiles hits one of these, even reading.  We really need to get the rest of the codebase off it.  At least you can't forget it's special anymore.