### PR TITLE
Migrate most of entity selection away from deprecated function + several bug fixes and tweaks

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -7166,7 +7166,7 @@ end)
 script.on_event("set-splitter-input-priority-left", function(event)
    pindex = event.player_index
    if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if not ent then
       return
    elseif ent.valid and ent.type == "splitter" then
@@ -7178,7 +7178,7 @@ end)
 script.on_event("set-splitter-input-priority-right", function(event)
    pindex = event.player_index
    if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if not ent then
       return
    elseif ent.valid and ent.type == "splitter" then
@@ -7190,7 +7190,7 @@ end)
 script.on_event("set-splitter-output-priority-left", function(event)
    local pindex = event.player_index
    if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if not ent then return end
    if ent.valid and ent.type == "splitter" then
       local result = fa_belts.set_splitter_priority(ent, false, true, nil)
@@ -7201,7 +7201,7 @@ end)
 script.on_event("set-splitter-output-priority-right", function(event)
    local pindex = event.player_index
    if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if not ent then return end
    --Build left turns on end rails
    if ent.valid and ent.type == "splitter" then
@@ -7220,7 +7220,7 @@ script.on_event("set-entity-filter-from-hand", function(event)
    else
       --Not in a menu
       local stack = game.get_player(pindex).cursor_stack
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       if ent == nil or ent.valid == false then return end
       if stack == nil or not stack.valid_for_read or not stack.valid then
          if ent.type == "splitter" then
@@ -7265,7 +7265,7 @@ script.on_event("connect-rail-vehicles", function(event)
    local pindex = event.player_index
    local vehicle = nil
    if not check_for_player(pindex) or players[pindex].in_menu then return end
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if game.get_player(pindex).vehicle ~= nil and game.get_player(pindex).vehicle.train ~= nil then
       vehicle = game.get_player(pindex).vehicle
    elseif ent ~= nil and ent.valid and ent.train ~= nil then
@@ -7297,7 +7297,7 @@ script.on_event("disconnect-rail-vehicles", function(event)
    local pindex = event.player_index
    local vehicle = nil
    if not check_for_player(pindex) or players[pindex].in_menu then return end
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if game.get_player(pindex).vehicle ~= nil and game.get_player(pindex).vehicle.train ~= nil then
       vehicle = game.get_player(pindex).vehicle
    elseif ent ~= nil and ent.train ~= nil then
@@ -7377,7 +7377,7 @@ end)
 --Attempt to launch a rocket
 script.on_event("launch-rocket", function(event)
    local pindex = event.player_index
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if not check_for_player(pindex) then return end
    --For rocket entities, return the silo instead
    if ent and (ent.name == "rocket-silo-rocket-shadow" or ent.name == "rocket-silo-rocket") then
@@ -7446,7 +7446,7 @@ script.on_event("debug-test-key", function(event)
    if not check_for_player(pindex) then return end
    local p = game.get_player(pindex)
    local pex = players[pindex]
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = p.selected
    local stack = game.get_player(pindex).cursor_stack
 
    game.print(ent.prototype.group.name)
@@ -8227,7 +8227,7 @@ function check_and_play_bump_alert_sound(pindex, this_tick)
    local bump_was_tile = false
 
    --Check if there is an ent in front of the player
-   local found_ent = get_selected_ent_deprecated(pindex)
+   local found_ent = p.selected
    local ent = nil
    if
       found_ent

--- a/control.lua
+++ b/control.lua
@@ -3034,7 +3034,7 @@ script.on_event("increase-inventory-bar-by-1", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu and (players[pindex].menu == "building" or players[pindex].menu == "vehicle") then
       --Chest bar setting: Increase
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       local result = fa_sectors.add_to_inventory_bar(ent, 1)
       printout(result, pindex)
    end
@@ -3045,7 +3045,7 @@ script.on_event("increase-inventory-bar-by-5", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu and (players[pindex].menu == "building" or players[pindex].menu == "vehicle") then
       --Chest bar setting: Increase
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       local result = fa_sectors.add_to_inventory_bar(ent, 5)
       printout(result, pindex)
    end
@@ -3056,7 +3056,7 @@ script.on_event("increase-inventory-bar-by-100", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu and (players[pindex].menu == "building" or players[pindex].menu == "vehicle") then
       --Chest bar setting: Increase
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       local result = fa_sectors.add_to_inventory_bar(ent, 100)
       printout(result, pindex)
    end
@@ -3067,7 +3067,7 @@ script.on_event("decrease-inventory-bar-by-1", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu and (players[pindex].menu == "building" or players[pindex].menu == "vehicle") then
       --Chest bar setting: Decrease
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       local result = fa_sectors.add_to_inventory_bar(ent, -1)
       printout(result, pindex)
    end
@@ -3078,7 +3078,7 @@ script.on_event("decrease-inventory-bar-by-5", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu and (players[pindex].menu == "building" or players[pindex].menu == "vehicle") then
       --Chest bar setting: Decrease
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       local result = fa_sectors.add_to_inventory_bar(ent, -5)
       printout(result, pindex)
    end
@@ -3089,7 +3089,7 @@ script.on_event("decrease-inventory-bar-by-100", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu and (players[pindex].menu == "building" or players[pindex].menu == "vehicle") then
       --Chest bar setting: Decrease
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       local result = fa_sectors.add_to_inventory_bar(ent, -100)
       printout(result, pindex)
    end
@@ -3140,7 +3140,7 @@ script.on_event("inserter-hand-stack-size-up", function(event)
    if not check_for_player(pindex) then return end
    local p = game.get_player(pindex)
    if p.opened and p.opened.type == "inserter" then
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       if ent.type == "inserter" then
          local result = fa_sectors.inserter_hand_stack_size_up(ent)
          printout(result, pindex)
@@ -3153,7 +3153,7 @@ script.on_event("inserter-hand-stack-size-down", function(event)
    if not check_for_player(pindex) then return end
    local p = game.get_player(pindex)
    if p.opened and p.opened.type == "inserter" then
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       if ent.type == "inserter" then
          local result = fa_sectors.inserter_hand_stack_size_down(ent)
          printout(result, pindex)
@@ -3164,7 +3164,7 @@ end)
 script.on_event("read-rail-structure-ahead", function(event)
    pindex = event.player_index
    if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if game.get_player(pindex).driving and game.get_player(pindex).vehicle.train ~= nil then
       fa_trains.train_read_next_rail_entity_ahead(pindex, false)
    elseif ent ~= nil and ent.valid and (ent.name == "straight-rail" or ent.name == "curved-rail") then
@@ -3198,7 +3198,7 @@ end)
 script.on_event("read-rail-structure-behind", function(event)
    pindex = event.player_index
    if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if game.get_player(pindex).driving and game.get_player(pindex).vehicle.train ~= nil then
       fa_trains.train_read_next_rail_entity_ahead(pindex, true)
    elseif ent ~= nil and ent.valid and (ent.name == "straight-rail" or ent.name == "curved-rail") then
@@ -3292,7 +3292,7 @@ script.on_event("scan-sort-by-distance", function(event)
    pindex = event.player_index
    if not check_for_player(pindex) then return end
    if not players[pindex].in_menu then
-      local ent = game.get_player(pindex).selected or get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       if ent ~= nil and ent.valid == true and (ent.get_control_behavior() ~= nil or ent.type == "electric-pole") then
          --Open the circuit network menu for the selected ent instead.
          return
@@ -4037,7 +4037,7 @@ script.on_event("mine-access-sounds", function(event)
    if not check_for_player(pindex) then return end
    if not players[pindex].in_menu and not players[pindex].vanilla_mode then
       target(pindex)
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       if ent and ent.valid and (ent.prototype.mineable_properties.products ~= nil) and ent.type ~= "resource" then
          game.get_player(pindex).selected = ent
          game.get_player(pindex).play_sound({ path = "player-mine" })
@@ -4113,7 +4113,7 @@ script.on_event("mine-area", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu then return end
    local p = game.get_player(pindex)
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    local cleared_count = 0
    local cleared_total = 0
    local comment = ""

--- a/control.lua
+++ b/control.lua
@@ -8438,7 +8438,7 @@ function selected_item_production_stats_info(pindex)
    end
 
    --Try crafting menu.
-   if internal_name == nil and players[pindex].menu == "crafting" then
+   if prototype == nil and players[pindex].menu == "crafting" then
       recipe = players[pindex].crafting.lua_recipes[players[pindex].crafting.category][players[pindex].crafting.index]
       if recipe and recipe.valid and recipe.products then
          local first_item, first_fluid

--- a/control.lua
+++ b/control.lua
@@ -6839,6 +6839,7 @@ function cursor_skip(pindex, direction, iteration_limit, use_preview_size)
          p.play_sound({ path = "inventory-wrap-around", position = players[pindex].position, volume_modifier = 1 })
       end
    elseif moved_count == 1 then
+      result = ""
       --Play Sound
       if players[pindex].remote_view then
          p.play_sound({ path = "Close-Inventory-Sound", position = players[pindex].cursor_pos, volume_modifier = 1 })

--- a/control.lua
+++ b/control.lua
@@ -531,6 +531,8 @@ function toggle_cursor_mode(pindex)
 
       --Teleport to the center of the nearest tile to align
       center_player_character(pindex)
+
+      --Finally, read the new tile
       read_tile(pindex, "Cursor mode enabled, ")
    else
       --Disable
@@ -543,11 +545,13 @@ function toggle_cursor_mode(pindex)
       players[pindex].player_direction = p.character.direction
       players[pindex].build_lock = false
       if p.driving and p.vehicle then p.vehicle.active = true end
-      read_tile(pindex, "Cursor mode disabled, ")
 
       --Close Remote view
       toggle_remote_view(pindex, false, true)
       p.close_map()
+
+      --Finally, read the new tile
+      read_tile(pindex, "Cursor mode disabled, ")
    end
    if players[pindex].cursor_size < 2 then
       --Update cursor highlight
@@ -577,12 +581,11 @@ function toggle_remote_view(pindex, force_true, force_false)
       players[pindex].cursor = true
       players[pindex].build_lock = false
       center_player_character(pindex)
-      printout("Remote view opened", pindex)
+      read_tile(pindex, "Remote view opened, ")
    else
       players[pindex].remote_view = false
-      players[pindex].cursor = false
       players[pindex].build_lock = false
-      printout("Remote view closed", pindex)
+      read_tile(pindex, "Remote view closed, ")
       game.get_player(pindex).close_map()
    end
 

--- a/control.lua
+++ b/control.lua
@@ -6367,42 +6367,22 @@ end)
 
 script.on_event("copy-entity-settings-info", function(event)
    local pindex = event.player_index
-   if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
-   local p = game.get_player(pindex)
-   if ent and ent.valid then p.selected = ent end
 end)
 
 script.on_event("paste-entity-settings-info", function(event)
    local pindex = event.player_index
-   if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
-   local p = game.get_player(pindex)
-   if ent and ent.valid then p.selected = ent end
 end)
 
 script.on_event("fast-entity-transfer-info", function(event)
    local pindex = event.player_index
-   if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
-   local p = game.get_player(pindex)
-   if ent and ent.valid then p.selected = ent end
 end)
 
 script.on_event("fast-entity-split-info", function(event)
    local pindex = event.player_index
-   if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
-   local p = game.get_player(pindex)
-   if ent and ent.valid then p.selected = ent end
 end)
 
 script.on_event("drop-cursor-info", function(event)
    local pindex = event.player_index
-   if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
-   local p = game.get_player(pindex)
-   if ent and ent.valid then p.selected = ent end
 end)
 
 script.on_event("read-hand", function(event)
@@ -6739,7 +6719,7 @@ script.on_event("open-structure-travel-menu", function(event)
       players[pindex].in_menu = true
       players[pindex].move_queue = {}
       players[pindex].structure_travel.direction = "none"
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       local initial_scan_radius = 50
       if ent ~= nil and ent.valid and ent.unit_number ~= nil and building_types[ent.type] then
          players[pindex].structure_travel.current = ent.unit_number

--- a/control.lua
+++ b/control.lua
@@ -459,12 +459,14 @@ function locate_hand_in_crafting_menu(pindex)
    fa_menu_search.fetch_next(pindex, item_name, nil)
 end
 
---If there is an entity to select, moves the mouse pointer to it, else moves to the cursor tile.
-function target(pindex)
+--If there is an entity at the cursor, moves the mouse pointer to it, else moves to the cursor tile.
+--TODO: remove this, by calling the appropriate mouse module functions instead.
+function target_mouse_pointer_deprecated(pindex)
    if players[pindex].vanilla_mode then return end
-   local ent = get_selected_ent_deprecated(pindex)
-   if ent then
-      fa_mouse.move_mouse_pointer(ent.position, pindex)
+   local surf = game.get_player(pindex).surface
+   local ents = surf.find_entities_filtered({ position = players[pindex].cursor_pos })
+   if ents and ents[1] and ents[1].valid then
+      fa_mouse.move_mouse_pointer(ents[1].position, pindex)
    else
       fa_mouse.move_mouse_pointer(players[pindex].cursor_pos, pindex)
    end
@@ -538,7 +540,6 @@ function toggle_cursor_mode(pindex)
       players[pindex].cursor_pos = fa_utils.center_of_tile(players[pindex].cursor_pos)
       fa_mouse.move_mouse_pointer(players[pindex].cursor_pos, pindex)
       fa_graphics.sync_build_cursor_graphics(pindex)
-      target(pindex)
       players[pindex].player_direction = p.character.direction
       players[pindex].build_lock = false
       if p.driving and p.vehicle then p.vehicle.active = true end
@@ -2500,7 +2501,7 @@ function move(direction, pindex)
       end
 
       if game.get_player(pindex).driving then
-         target(pindex)
+         target_mouse_pointer_deprecated(pindex)
          return
       end
 
@@ -2518,7 +2519,7 @@ function move(direction, pindex)
                   .can_place_entity({ name = "character", position = players[pindex].cursor_pos })
             )
          then
-            target(pindex)
+            target_mouse_pointer_deprecated(pindex)
             read_tile(pindex)
          end
       end
@@ -4036,7 +4037,6 @@ script.on_event("mine-access-sounds", function(event)
    pindex = event.player_index
    if not check_for_player(pindex) then return end
    if not players[pindex].in_menu and not players[pindex].vanilla_mode then
-      target(pindex)
       local ent = game.get_player(pindex).selected
       if ent and ent.valid and (ent.prototype.mineable_properties.products ~= nil) and ent.type ~= "resource" then
          game.get_player(pindex).selected = ent

--- a/control.lua
+++ b/control.lua
@@ -5965,7 +5965,7 @@ script.on_event("item-production-info", function(event)
    pindex = event.player_index
    if not check_for_player(pindex) then return end
    if game.get_player(pindex).driving then return end
-   local str = selected_item_production_stats_info(pindex)
+   local str = fa_info.selected_item_production_stats_info(pindex)
    printout(str, pindex)
 end)
 
@@ -8374,120 +8374,6 @@ function general_mod_menu_down(pindex, menu, upper_limit)
       --Play sound
       game.get_player(pindex).play_sound({ path = "Inventory-Move" })
    end
-end
-
---Report total produced and consumed in last minute, ten minutes,  hour,
---thousand hours for the selected item.  The selected item comes from the item
---in hand, the selected item in an inventory, or the crafting menu's current
---selection, in that order.  Since the latter two are disjunct, this can also be
---phrased as "in hand, otherwise examine menus".  Note that Factorio stores
---fluids and items in different places, and that the complicated branching below
---must also account for that.
---
--- Recipes may also produce items as well as fluids.  In vanilla, the example is
--- barrels.  We can't do the right thing in all cases, but in vanilla it happens
--- that the stats on barrels aren't super important and, additionally, there's a
--- separate recipe one can check for that.  Since this only outputs one entry
--- when selecting a recipe, we choose the first fluid if there is one, otherwise
--- the first item.  Ultimately for mods, we're going to need a GUI for it: there
--- are too many cases in the wild.
-function selected_item_production_stats_info(pindex)
-   local p = game.get_player(pindex)
-   local stats = p.force.item_production_statistics
-   local item_stack = nil
-   local recipe = nil
-
-   -- Try the cursor stack
-   item_stack = p.cursor_stack
-   if item_stack and item_stack.valid_for_read then prototype = item_stack.prototype end
-
-   --Otherwise try to get it from the inventory.
-   if prototype == nil and players[pindex].menu == "inventory" then
-      item_stack = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
-      if item_stack and item_stack.valid_for_read then prototype = item_stack.prototype end
-   end
-
-   --Try crafting menu.
-   if prototype == nil and players[pindex].menu == "crafting" then
-      recipe = players[pindex].crafting.lua_recipes[players[pindex].crafting.category][players[pindex].crafting.index]
-      if recipe and recipe.valid and recipe.products then
-         local first_item, first_fluid
-         for i, prod in ipairs(recipe.products) do
-            if first_item and first_fluid then
-               break
-            elseif prod.type == "item" then
-               first_item = prod
-            elseif prod.type == "fluid" then
-               first_fluid = prod
-            end
-         end
-
-         local chosen = first_fluid or first_item
-
-         if not chosen then
-            -- do nothing
-         elseif chosen.type == "item" then
-            --Select product item #1
-            prototype = game.item_prototypes[chosen.name]
-         elseif chosen.type == "fluid" then
-            --Select product fluid #1
-            stats = p.force.fluid_production_statistics
-            prototype = game.fluid_prototypes[chosen.name]
-         end
-      end
-   end
-
-   -- For now, we give up.
-   if not prototype then return "Error: No selected item or fluid" end
-
-   -- We need both inputs and outputs. That's the same code, with one boolean
-   -- changed.
-   local get_stats = function(is_input)
-      local name = prototype.name
-      local interval = defines.flow_precision_index
-      local last_minute =
-         stats.get_flow_count({ name = name, input = is_input, precision_index = interval.one_minute, count = true })
-      local last_10_minutes =
-         stats.get_flow_count({ name = name, input = is_input, precision_index = interval.ten_minutes, count = true })
-      local last_hour =
-         stats.get_flow_count({ name = name, input = is_input, precision_index = interval.one_hour, count = true })
-      local thousand_hours = stats.get_flow_count({
-         name = name,
-         input = is_input,
-         precision_index = interval.one_thousand_hours,
-         count = true,
-      })
-      last_minute = fa_utils.simplify_large_number(last_minute)
-      last_10_minutes = fa_utils.simplify_large_number(last_10_minutes)
-      last_hour = fa_utils.simplify_large_number(last_hour)
-      thousand_hours = fa_utils.simplify_large_number(thousand_hours)
-      return last_minute, last_10_minutes, last_hour, thousand_hours
-   end
-
-   local m1_in, m10_in, h1_in, h1000_in = get_stats(true)
-   local m1_out, m10_out, h1_out, h1000_out = get_stats(false)
-
-   return fa_utils.spacecat(
-      fa_localising.get(prototype, pindex) .. ".",
-      "Produced",
-      m1_in,
-      "last minute,",
-      m10_in,
-      "last ten min,",
-      h1_in,
-      "last hour,",
-      h1000_in,
-      "last 1k hours.",
-      "Consumed",
-      m1_out,
-      "last minute,",
-      m10_out,
-      "last ten min,",
-      h1_out,
-      "last hour,",
-      h1000_out,
-      "last 1k hours."
-   )
 end
 
 script.on_event("fa-pda-driving-assistant-info", function(event)

--- a/control.lua
+++ b/control.lua
@@ -633,7 +633,6 @@ end
 
 function return_cursor_to_character(pindex)
    if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
    if not players[pindex].in_menu then
       if players[pindex].cursor then jump_to_player(pindex) end
    end
@@ -4959,7 +4958,6 @@ script.on_event("click-hand-right", function(event)
    else
       --Not in a menu
       local stack = game.get_player(pindex).cursor_stack
-      local ent = get_selected_ent_deprecated(pindex)
 
       if stack and stack.valid_for_read and stack.valid then
          players[pindex].last_click_tick = event.tick
@@ -5225,7 +5223,6 @@ script.on_event("repair-area", function(event)
    else
       --Not in a menu
       local stack = game.get_player(pindex).cursor_stack
-      local ent = get_selected_ent_deprecated(pindex)
 
       if stack and stack.valid_for_read and stack.valid then
          players[pindex].last_click_tick = event.tick
@@ -5407,7 +5404,7 @@ script.on_event("open-rail-builder", function(event)
       fa_rails.end_ghost_rail_planning(pindex)
    else
       --Not in a menu
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       local stack = game.get_player(pindex).cursor_stack
       if ent then
          if ent.name == "straight-rail" then
@@ -5434,7 +5431,7 @@ end)
 script.on_event("quick-build-rail-left-turn", function(event)
    local pindex = event.player_index
    if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if not ent then return end
    --Build left turns on end rails
    if ent.name == "straight-rail" then fa_rail_builder.build_rail_turn_left_45_degrees(ent, pindex) end
@@ -5443,7 +5440,7 @@ end)
 script.on_event("quick-build-rail-right-turn", function(event)
    local pindex = event.player_index
    if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if not ent then return end
    --Build left turns on end rails
    if ent.name == "straight-rail" then fa_rail_builder.build_rail_turn_right_45_degrees(ent, pindex) end
@@ -5474,7 +5471,6 @@ script.on_event("fa-alternate-build", function(event)
    else
       --Not in a menu
       local stack = game.get_player(pindex).cursor_stack
-      local ent = get_selected_ent_deprecated(pindex)
       if stack == nil or stack.valid_for_read == false or stack.valid == false then
          return
       elseif stack.name == "rail" then
@@ -5640,8 +5636,6 @@ end
 script.on_event("crafting-5", function(event)
    pindex = event.player_index
    if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
-   local stack = game.get_player(pindex).cursor_stack
    if players[pindex].in_menu then
       if players[pindex].menu == "crafting" then
          local recipe =
@@ -5685,8 +5679,6 @@ end)
 script.on_event("menu-clear-filter", function(event)
    pindex = event.player_index
    if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
-   local stack = game.get_player(pindex).cursor_stack
    if players[pindex].in_menu then
       if players[pindex].menu == "building" or players[pindex].menu == "vehicle" then
          local stack = game.get_player(pindex).cursor_stack
@@ -5804,9 +5796,8 @@ script.on_event("item-info", function(event)
       offset = 1
    end
    if not players[pindex].in_menu then
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       if ent and ent.valid then
-         game.get_player(pindex).selected = ent
          local str = ent.localised_description
          if str == nil or str == "" then str = "No description for this entity" end
          printout(str, pindex)
@@ -6351,10 +6342,9 @@ end)
 script.on_event("pipette-tool-info", function(event)
    local pindex = event.player_index
    if not check_for_player(pindex) then return end
-   local ent = get_selected_ent_deprecated(pindex)
    local p = game.get_player(pindex)
+   local ent = p.selected
    if ent and ent.valid then
-      p.selected = ent
       if ent.supports_direction then
          players[pindex].building_direction = ent.direction
          players[pindex].cursor_rotation_offset = 0

--- a/control.lua
+++ b/control.lua
@@ -3034,7 +3034,7 @@ script.on_event("increase-inventory-bar-by-1", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu and (players[pindex].menu == "building" or players[pindex].menu == "vehicle") then
       --Chest bar setting: Increase
-      local ent = game.get_player(pindex).selected
+      local ent = game.get_player(pindex).opened
       local result = fa_sectors.add_to_inventory_bar(ent, 1)
       printout(result, pindex)
    end
@@ -3045,7 +3045,7 @@ script.on_event("increase-inventory-bar-by-5", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu and (players[pindex].menu == "building" or players[pindex].menu == "vehicle") then
       --Chest bar setting: Increase
-      local ent = game.get_player(pindex).selected
+      local ent = game.get_player(pindex).opened
       local result = fa_sectors.add_to_inventory_bar(ent, 5)
       printout(result, pindex)
    end
@@ -3056,7 +3056,7 @@ script.on_event("increase-inventory-bar-by-100", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu and (players[pindex].menu == "building" or players[pindex].menu == "vehicle") then
       --Chest bar setting: Increase
-      local ent = game.get_player(pindex).selected
+      local ent = game.get_player(pindex).opened
       local result = fa_sectors.add_to_inventory_bar(ent, 100)
       printout(result, pindex)
    end
@@ -3067,7 +3067,7 @@ script.on_event("decrease-inventory-bar-by-1", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu and (players[pindex].menu == "building" or players[pindex].menu == "vehicle") then
       --Chest bar setting: Decrease
-      local ent = game.get_player(pindex).selected
+      local ent = game.get_player(pindex).opened
       local result = fa_sectors.add_to_inventory_bar(ent, -1)
       printout(result, pindex)
    end
@@ -3078,7 +3078,7 @@ script.on_event("decrease-inventory-bar-by-5", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu and (players[pindex].menu == "building" or players[pindex].menu == "vehicle") then
       --Chest bar setting: Decrease
-      local ent = game.get_player(pindex).selected
+      local ent = game.get_player(pindex).opened
       local result = fa_sectors.add_to_inventory_bar(ent, -5)
       printout(result, pindex)
    end
@@ -3089,7 +3089,7 @@ script.on_event("decrease-inventory-bar-by-100", function(event)
    if not check_for_player(pindex) then return end
    if players[pindex].in_menu and (players[pindex].menu == "building" or players[pindex].menu == "vehicle") then
       --Chest bar setting: Decrease
-      local ent = game.get_player(pindex).selected
+      local ent = game.get_player(pindex).opened
       local result = fa_sectors.add_to_inventory_bar(ent, -100)
       printout(result, pindex)
    end
@@ -3140,7 +3140,7 @@ script.on_event("inserter-hand-stack-size-up", function(event)
    if not check_for_player(pindex) then return end
    local p = game.get_player(pindex)
    if p.opened and p.opened.type == "inserter" then
-      local ent = game.get_player(pindex).selected
+      local ent = game.get_player(pindex).opened
       if ent.type == "inserter" then
          local result = fa_sectors.inserter_hand_stack_size_up(ent)
          printout(result, pindex)
@@ -3153,7 +3153,7 @@ script.on_event("inserter-hand-stack-size-down", function(event)
    if not check_for_player(pindex) then return end
    local p = game.get_player(pindex)
    if p.opened and p.opened.type == "inserter" then
-      local ent = game.get_player(pindex).selected
+      local ent = game.get_player(pindex).opened
       if ent.type == "inserter" then
          local result = fa_sectors.inserter_hand_stack_size_down(ent)
          printout(result, pindex)

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -6,6 +6,9 @@ end
 ---Apply universal belt immunity
 data.raw.character.character.has_belt_immunity = true
 
+---Make the character unlikely to be selected by the mouse pointer when overlapping with entities
+data.raw.character.character.selection_priority = 2
+
 for _, item in pairs(vanilla_tip_and_tricks_item_table) do
    remove_tip_and_tricks_item(item)
 end

--- a/scripts/building-tools.lua
+++ b/scripts/building-tools.lua
@@ -305,7 +305,7 @@ function mod.build_item_in_hand(pindex, free_place_straight_rail)
    end
 
    --Update cursor highlight (end)
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if ent and ent.valid then
       fa_graphics.draw_cursor_highlight(pindex, ent, nil)
    else
@@ -363,11 +363,12 @@ end
 --Reads the result of trying to rotate a building, which is a vanilla action.
 function mod.rotate_building_info_read(event, forward)
    pindex = event.player_index
+   local p = game.get_player(pindex)
    if not check_for_player(pindex) then return end
    local mult = 1
    if forward == false then mult = -1 end
    if players[pindex].in_menu == false or players[pindex].menu == "blueprint_menu" then
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = p.selected
       local stack = game.get_player(pindex).cursor_stack
       local build_dir = players[pindex].building_direction
       if stack and stack.valid_for_read and stack.valid and stack.prototype.place_result ~= nil then
@@ -482,7 +483,7 @@ function mod.nudge_key(direction, event)
    local pindex = event.player_index
    local p = game.get_player(pindex)
    if not check_for_player(pindex) or players[pindex].menu == "prompt" then return end
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = p.selected
    if ent and ent.valid then
       if ent.force == game.get_player(pindex).force then
          local old_pos = ent.position

--- a/scripts/fa-info.lua
+++ b/scripts/fa-info.lua
@@ -1140,6 +1140,7 @@ function mod.selected_item_production_stats_info(pindex)
    local stats = p.force.item_production_statistics
    local item_stack = nil
    local recipe = nil
+   local prototype = nil
 
    -- Try the cursor stack
    item_stack = p.cursor_stack
@@ -1212,7 +1213,7 @@ function mod.selected_item_production_stats_info(pindex)
    local m1_out, m10_out, h1_out, h1000_out = get_stats(false)
 
    return fa_utils.spacecat(
-      fa_localising.get(prototype, pindex) .. ".",
+      fa_localising.get(prototype, pindex) .. ",",
       "Produced",
       m1_in,
       "last minute,",

--- a/scripts/fa-info.lua
+++ b/scripts/fa-info.lua
@@ -1204,7 +1204,7 @@ end
 
 --Report the status of the selected entity as well as additional dynamic info depending on the entity type
 function mod.read_selected_entity_status(pindex)
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if not ent then return end
    local stack = game.get_player(pindex).cursor_stack
    if players[pindex].in_menu then return end

--- a/scripts/fa-info.lua
+++ b/scripts/fa-info.lua
@@ -1120,86 +1120,118 @@ function mod.read_nearest_damaged_ent_info(pos, pindex)
    end
 end
 
---Report total produced in last minute, last hour, last thousand hours for the selected item, either in hand or else selected from player inventory.
+--Report total produced and consumed in last minute, ten minutes,  hour,
+--thousand hours for the selected item.  The selected item comes from the item
+--in hand, the selected item in an inventory, or the crafting menu's current
+--selection, in that order.  Since the latter two are disjunct, this can also be
+--phrased as "in hand, otherwise examine menus".  Note that Factorio stores
+--fluids and items in different places, and that the complicated branching below
+--must also account for that.
+--
+-- Recipes may also produce items as well as fluids.  In vanilla, the example is
+-- barrels.  We can't do the right thing in all cases, but in vanilla it happens
+-- that the stats on barrels aren't super important and, additionally, there's a
+-- separate recipe one can check for that.  Since this only outputs one entry
+-- when selecting a recipe, we choose the first fluid if there is one, otherwise
+-- the first item.  Ultimately for mods, we're going to need a GUI for it: there
+-- are too many cases in the wild.
 function mod.selected_item_production_stats_info(pindex)
    local p = game.get_player(pindex)
-   local result = ""
    local stats = p.force.item_production_statistics
-   local internal_name = nil
    local item_stack = nil
    local recipe = nil
 
-   --Select the cursor stack
+   -- Try the cursor stack
    item_stack = p.cursor_stack
-   if item_stack and item_stack.valid_for_read then internal_name = item_stack.prototype.name end
+   if item_stack and item_stack.valid_for_read then prototype = item_stack.prototype end
 
-   --Otherwise select the selected inventory stack
-   if internal_name == nil and players[pindex].menu == "inventory" then
+   --Otherwise try to get it from the inventory.
+   if prototype == nil and players[pindex].menu == "inventory" then
       item_stack = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
-      if item_stack and item_stack.valid_for_read then internal_name = item_stack.prototype.name end
+      if item_stack and item_stack.valid_for_read then prototype = item_stack.prototype end
    end
 
-   --Otherwise select the selected crafting recipe
-   if internal_name == nil and players[pindex].menu == "crafting" then
+   --Try crafting menu.
+   if prototype == nil and players[pindex].menu == "crafting" then
       recipe = players[pindex].crafting.lua_recipes[players[pindex].crafting.category][players[pindex].crafting.index]
-      if recipe and recipe.valid and recipe.products and recipe.products[1] then
-         local prototype = nil
-         if recipe.products[1].type == "item" then
-            --Select product item #1
-            prototype = game.item_prototypes[recipe.products[1].name]
-            if prototype then
-               internal_name = prototype.name
-               result = fa_localising.get_item_from_name(recipe.products[1].name, pindex) .. " "
+      if recipe and recipe.valid and recipe.products then
+         local first_item, first_fluid
+         for i, prod in ipairs(recipe.products) do
+            if first_item and first_fluid then
+               break
+            elseif prod.type == "item" then
+               first_item = prod
+            elseif prod.type == "fluid" then
+               first_fluid = prod
             end
          end
-         if recipe.products[1].type == "fluid" then
+
+         local chosen = first_fluid or first_item
+
+         if not chosen then
+            -- do nothing
+         elseif chosen.type == "item" then
+            --Select product item #1
+            prototype = game.item_prototypes[chosen.name]
+         elseif chosen.type == "fluid" then
             --Select product fluid #1
             stats = p.force.fluid_production_statistics
-            prototype = game.fluid_prototypes[recipe.name]
-            if prototype then
-               internal_name = prototype.name
-               result = fa_localising.get_fluid_from_name(recipe.products[1].name, pindex) .. " "
-            end
-         end
-         if recipe.products[2] and recipe.products[2].type == "fluid" then
-            --Select product fluid #2 (instead)
-            stats = p.force.fluid_production_statistics
-            prototype = game.fluid_prototypes[recipe.products[2].name]
-            if prototype then
-               internal_name = prototype.name
-               result = fa_localising.get_fluid_from_name(recipe.products[2].name, pindex) .. " "
-            end
+            prototype = game.fluid_prototypes[chosen.name]
          end
       end
    end
 
-   if internal_name == nil then
-      result = "Error: No selected item or fluid"
-      return result
+   -- For now, we give up.
+   if not prototype then return "Error: No selected item or fluid" end
+
+   -- We need both inputs and outputs. That's the same code, with one boolean
+   -- changed.
+   local get_stats = function(is_input)
+      local name = prototype.name
+      local interval = defines.flow_precision_index
+      local last_minute =
+         stats.get_flow_count({ name = name, input = is_input, precision_index = interval.one_minute, count = true })
+      local last_10_minutes =
+         stats.get_flow_count({ name = name, input = is_input, precision_index = interval.ten_minutes, count = true })
+      local last_hour =
+         stats.get_flow_count({ name = name, input = is_input, precision_index = interval.one_hour, count = true })
+      local thousand_hours = stats.get_flow_count({
+         name = name,
+         input = is_input,
+         precision_index = interval.one_thousand_hours,
+         count = true,
+      })
+      last_minute = fa_utils.simplify_large_number(last_minute)
+      last_10_minutes = fa_utils.simplify_large_number(last_10_minutes)
+      last_hour = fa_utils.simplify_large_number(last_hour)
+      thousand_hours = fa_utils.simplify_large_number(thousand_hours)
+      return last_minute, last_10_minutes, last_hour, thousand_hours
    end
-   local interval = defines.flow_precision_index
-   local last_minute =
-      stats.get_flow_count({ name = internal_name, input = true, precision_index = interval.one_minute, count = true })
-   local last_10_minutes =
-      stats.get_flow_count({ name = internal_name, input = true, precision_index = interval.ten_minutes, count = true })
-   local last_hour =
-      stats.get_flow_count({ name = internal_name, input = true, precision_index = interval.one_hour, count = true })
-   local thousand_hours = stats.get_flow_count({
-      name = internal_name,
-      input = true,
-      precision_index = interval.one_thousand_hours,
-      count = true,
-   })
-   last_minute = fa_utils.simplify_large_number(last_minute)
-   last_10_minutes = fa_utils.simplify_large_number(last_10_minutes)
-   last_hour = fa_utils.simplify_large_number(last_hour)
-   thousand_hours = fa_utils.simplify_large_number(thousand_hours)
-   result = result .. " Produced "
-   result = result .. last_minute .. " in the last minute, "
-   result = result .. last_10_minutes .. " in the last 10 minutes, "
-   result = result .. last_hour .. " in the last hour, "
-   result = result .. thousand_hours .. " in the last one thousand hours, "
-   return result
+
+   local m1_in, m10_in, h1_in, h1000_in = get_stats(true)
+   local m1_out, m10_out, h1_out, h1000_out = get_stats(false)
+
+   return fa_utils.spacecat(
+      fa_localising.get(prototype, pindex) .. ".",
+      "Produced",
+      m1_in,
+      "last minute,",
+      m10_in,
+      "last ten min,",
+      h1_in,
+      "last hour,",
+      h1000_in,
+      "last thousand hours.",
+      "Consumed",
+      m1_out,
+      "last minute,",
+      m10_out,
+      "last ten min,",
+      h1_out,
+      "last hour,",
+      h1000_out,
+      "last thousand hours."
+   )
 end
 
 --Report the status of the selected entity as well as additional dynamic info depending on the entity type

--- a/scripts/quickbar.lua
+++ b/scripts/quickbar.lua
@@ -67,7 +67,7 @@ function mod.set_quick_bar_slot(index, pindex)
    local page = game.get_player(pindex).get_active_quick_bar_page(1) - 1
    local stack_cur = game.get_player(pindex).cursor_stack
    local stack_inv = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = p.selected
    if stack_cur and stack_cur.valid_for_read and stack_cur.valid == true then
       game.get_player(pindex).set_quick_bar_slot(index + 10 * page, stack_cur)
       printout("Quickbar assigned " .. index .. " " .. fa_localising.get(stack_cur, pindex), pindex)

--- a/scripts/spidertron.lua
+++ b/scripts/spidertron.lua
@@ -8,7 +8,7 @@ function mod.run_spider_menu(menu_index, pindex, spiderin, clicked, other_input)
    local spider
    local remote = game.get_player(pindex).cursor_stack
    local other = other_input or -1
-   local cursortarget = get_selected_ent_deprecated(pindex)
+   local cursortarget = game.get_player(pindex).selected
    local spidertron = game.get_player(pindex).cursor_stack.connected_entity
    if spiderin ~= nil then spider = spiderin end
    if index == 0 then

--- a/scripts/trains.lua
+++ b/scripts/trains.lua
@@ -417,7 +417,7 @@ function mod.run_train_menu(menu_index, pindex, clicked, other_input)
    local index = menu_index
    local other = other_input or -1
    local locomotive = nil
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if game.get_player(pindex).vehicle ~= nil and game.get_player(pindex).vehicle.name == "locomotive" then
       locomotive = game.get_player(pindex).vehicle
       players[pindex].train_menu.locomotive = locomotive

--- a/scripts/travel-tools.lua
+++ b/scripts/travel-tools.lua
@@ -442,7 +442,7 @@ function mod.fast_travel_menu_click(pindex)
       end
 
       --Update cursor highlight
-      local ent = get_selected_ent_deprecated(pindex)
+      local ent = game.get_player(pindex).selected
       if ent and ent.valid then
          fa_graphics.draw_cursor_highlight(pindex, ent, nil)
       else

--- a/scripts/worker-robots.lua
+++ b/scripts/worker-robots.lua
@@ -959,7 +959,7 @@ function mod.logistics_info_key_handler(pindex)
          if prototype then mod.player_logistic_request_read(prototype, pindex, true) end
       else
          --Logistic chest in front
-         local ent = get_selected_ent_deprecated(pindex)
+         local ent = game.get_player(pindex).selected
          if mod.can_make_logistic_requests(ent) then
             mod.read_entity_requests_summary(ent, pindex)
             return
@@ -1914,7 +1914,7 @@ end
 function mod.run_roboport_menu(menu_index, pindex, clicked)
    local index = menu_index
    local port = nil
-   local ent = get_selected_ent_deprecated(pindex)
+   local ent = game.get_player(pindex).selected
    if game.get_player(pindex).opened ~= nil and game.get_player(pindex).opened.name == "roboport" then
       port = game.get_player(pindex).opened
       players[pindex].roboport_menu.port = port


### PR DESCRIPTION
In the migrations, `get_selected_ent_deprecated` has been replaced with `player.selected` and `player.opened` and tested. Some replacement work still remains for the harder cases. While testing, other bugs and issues have come up and were fixed. These changes cover several source files. @EphDoering  noted approval but @ahicks92 I do not know about your ongoing edits, so feel free to merge this after you have checked it out. I would prefer a fast forward merge for easier bisecting if needed late, but you would know better.

Notable other changes:
- It turns out that the function for production info reading was misplaced before its upgrade in #170. This was due to incomplete migration into the fa_info module. The upgraded version was moved into the module and had minor issues fixed.
- In `data-updates.lua`,The selection priority for player characters was decreased to 2 instead of some  triple digit number so that when the character overlaps with other entities, the mouse pointer selects the other entities.
- When the cursor skips by just 1 tile, it no longer says that it skipped (it should not have).
- A mouse pointer moving function inside `control.lua` was noted as deprecated but not yet fully removed.
- The reporting about opening and closing of Remote View was fixed. The new behavior correctly reflects how remote view is an extension of cursor mode:
  - Whether you open or close cursor mode or remote view, the selected tile is read.
  - Opening cursor mode has no effect on remote view, because it is an additional system.
  - Opening remote view always opens cursor mode, because it is a dependency, and keeps the cursor in place.
  - Closing remote view restores the usual cursor mode, and keeps the cursor in place.
  - Closing cursor mode returns the cursor to the player and forces the closing of remote view, which depends on cursor mode.
