### PR TITLE
Inventory slot filters

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -204,7 +204,8 @@ end
 
 --Reads the selected player inventory's selected menu slot. Default is to read the main inventory.
 function read_inventory_slot(pindex, start_phrase_in, inv_in)
-   local start_phrase = start_phrase_in or ""
+   local p = game.get_player(pindex)
+   local result = start_phrase_in or ""
    local index = players[pindex].inventory.index
    local inv = inv_in or players[pindex].inventory.lua_inventory
    if index < 1 then
@@ -215,20 +216,22 @@ function read_inventory_slot(pindex, start_phrase_in, inv_in)
    players[pindex].inventory.index = index
    local stack = inv[index]
    if stack == nil or not stack.valid_for_read then
-      printout(start_phrase .. "Empty Slot", pindex)
+      --Label it as an empty slot
+      result = result .. "Empty Slot"
+      --Check if the empty slot has a filter set
+      local filter_name = p.get_main_inventory().get_filter(index)
+      if filter_name ~= nil then
+         result = result .. " filtered for " .. filter_name --laterdo localise this name
+      end
+      printout(result, pindex)
       return
    end
    if stack.is_blueprint then
       printout(fa_blueprints.get_blueprint_info(stack, false), pindex)
    elseif stack.valid_for_read then
-      if stack.health < 1 then start_phrase = start_phrase .. " damaged " end
+      if stack.health < 1 then result = result .. " damaged " end
       printout(
-         start_phrase
-            .. fa_localising.get(stack, pindex)
-            .. " x "
-            .. stack.count
-            .. " "
-            .. stack.prototype.subgroup.name,
+         result .. fa_localising.get(stack, pindex) .. " x " .. stack.count .. " " .. stack.prototype.subgroup.name,
          pindex
       )
    end

--- a/control.lua
+++ b/control.lua
@@ -7263,12 +7263,14 @@ function set_selected_inventory_slot_filter(pindex)
 
    --1. If a  filter is set then clear it
    if filter ~= nil then
-      printout("Filter cleared", pindex)
+      inv.set_filter(index, nil)
+      read_inventory_slot(pindex, "Slot filter cleared, ")
       return
    --2. If no filter is set and both the slot and hand are full, then choose the slot item (because otherwise it needs to be moved)
    elseif slot_item and slot_item.valid_for_read and hand_item and hand_item.valid_for_read then
       if inv.can_set_filter(index, slot_item.name) then
          inv.set_filter(index, slot_item.name)
+         read_inventory_slot(pindex, "Slot filter set, ")
       else
          printout("Error: Unable to set the slot filter for this item", pindex)
       end
@@ -7277,6 +7279,7 @@ function set_selected_inventory_slot_filter(pindex)
    elseif slot_item and slot_item.valid_for_read then
       if inv.can_set_filter(index, slot_item.name) then
          inv.set_filter(index, slot_item.name)
+         read_inventory_slot(pindex, "Slot filter set, ")
       else
          printout("Error: Unable to set the slot filter for this item", pindex)
       end
@@ -7285,6 +7288,7 @@ function set_selected_inventory_slot_filter(pindex)
    elseif hand_item and hand_item.valid_for_read then
       if inv.can_set_filter(index, hand_item.name) then
          inv.set_filter(index, hand_item.name)
+         read_inventory_slot(pindex, "Slot filter set, ")
       else
          printout("Error: Unable to set the slot filter for this item", pindex)
       end
@@ -7296,17 +7300,29 @@ function set_selected_inventory_slot_filter(pindex)
    end
 end
 
---Returns the currently selected entity inventory based on the current mod menu and mod sector. TODO
+--Returns the currently selected entity inventory based on the current mod menu and mod sector.
 function get_selected_inventory_and_slot(pindex)
+   local p = game.get_player(pindex)
    local inv = nil
-   if players[pindex].menu == "inventory" then
-      --TODO
-   elseif players[pindex].menu == "building" then
-      --TODO
-   elseif players[pindex].menu == "vehicle" then
-      --TODO
+   local index = nil
+   local menu = players[pindex].menu
+   if menu == "inventory" then
+      inv = p.get_main_inventory()
+      index = players[pindex].inventory.index
+   elseif menu == "player_trash" then
+      inv = p.get_inventory(defines.inventory.player_trash)
+      index = players[pindex].inventory.index
+   elseif menu == "building" then
+      local sector_name = players[pindex].building.sector_name
+      index = players[pindex].building.index
+   elseif menu == "vehicle" then
+      local sector_name = players[pindex].building.sector_name
+      index = players[pindex].building.index
    end
+   return inv, index
 end
+
+function read_inv_slot_filter() end
 
 -- G is used to connect rolling stock
 script.on_event("connect-rail-vehicles", function(event)

--- a/data.lua
+++ b/data.lua
@@ -1726,6 +1726,13 @@ data:extend({
 
    {
       type = "custom-input",
+      name = "toggle-inventory-slot-filter",
+      key_sequence = "ALT + LEFTBRACKET",
+      consuming = "none",
+   },
+
+   {
+      type = "custom-input",
       name = "set-entity-filter-from-hand",
       key_sequence = "CONTROL + LEFTBRACKET",
       consuming = "none",

--- a/scripts/building-vehicle-sectors.lua
+++ b/scripts/building-vehicle-sectors.lua
@@ -550,6 +550,14 @@ function mod.read_sector_slot(pindex, prefix_inventory_size_and_name, start_phra
       else
          --Read the "empty slot"
          local result = "Empty slot"
+         --Check if the empty slot has a filter set
+         if building_sector.inventory.supports_filters() then
+            local index = players[pindex].building.index
+            local filter_name = building_sector.inventory.get_filter(index)
+            if filter_name ~= nil then
+               result = result .. " filtered for " .. filter_name --laterdo localise this name
+            end
+         end
          if building_sector.name == "Modules" then result = "Empty module slot" end
          local recipe = players[pindex].building.recipe
          if recipe ~= nil then

--- a/scripts/building-vehicle-sectors.lua
+++ b/scripts/building-vehicle-sectors.lua
@@ -413,12 +413,14 @@ function mod.read_building_recipe(pindex, start_phrase)
 end
 
 --Building sectors: Read the item or fluid at the selected slot.
-function mod.read_sector_slot(pindex, prefix_inventory_size_and_name)
+function mod.read_sector_slot(pindex, prefix_inventory_size_and_name, start_phrase_in)
    local building_sector = players[pindex].building.sectors[players[pindex].building.sector]
+   local start_phrase = start_phrase_in or ""
    if building_sector.name == "Filters" then
       local inventory = building_sector.inventory
-      local start_phrase = #inventory .. " " .. building_sector.name .. ", "
-      if not prefix_inventory_size_and_name then start_phrase = "" end
+      if prefix_inventory_size_and_name then
+         start_phrase = start_phrase .. #inventory .. " " .. building_sector.name .. ", "
+      end
       printout(
          start_phrase
             .. players[pindex].building.index
@@ -448,8 +450,9 @@ function mod.read_sector_slot(pindex, prefix_inventory_size_and_name)
       local type = box.get_prototype(players[pindex].building.index).production_type
       local fluid = box[players[pindex].building.index]
       local len = #box
-      local start_phrase = len .. " " .. building_sector.name .. ", "
-      if not prefix_inventory_size_and_name then start_phrase = "" end
+      if prefix_inventory_size_and_name then
+         start_phrase = start_phrase .. len .. " " .. building_sector.name .. ", "
+      end
       --fluid = {name = "water", amount = 1}
       local name = "Any"
       local amount = 0
@@ -511,14 +514,15 @@ function mod.read_sector_slot(pindex, prefix_inventory_size_and_name)
    elseif #building_sector.inventory > 0 then
       --Item inventories
       local inventory = building_sector.inventory
-      local start_phrase = #inventory .. " " .. building_sector.name .. ", "
-      if inventory.supports_bar() and #inventory > inventory.get_bar() - 1 then
-         --local unlocked = inventory.supports_bar() and inventory.get_bar() - 1 or nil
-         local unlocked = inventory.get_bar() - 1
-         start_phrase = start_phrase .. ", " .. unlocked .. " unlocked, "
+      if prefix_inventory_size_and_name then
+         start_phrase = start_phrase .. #inventory .. " " .. building_sector.name .. ", "
+         if inventory.supports_bar() and #inventory > inventory.get_bar() - 1 then
+            --local unlocked = inventory.supports_bar() and inventory.get_bar() - 1 or nil
+            local unlocked = inventory.get_bar() - 1
+            start_phrase = start_phrase .. ", " .. unlocked .. " unlocked, "
+         end
       end
-      if not prefix_inventory_size_and_name then start_phrase = "" end
-      --Mention if a slot is locked
+      --Mention if the selected slot is locked
       if inventory.supports_bar() and players[pindex].building.index > inventory.get_bar() - 1 then
          start_phrase = start_phrase .. " locked "
       end


### PR DESCRIPTION
This satisfies #190 except for the part with the item selector menu. 
For a player or vehicle main inventory, press ALT + LEFT BRACKET to set or unset the item filter for the selected inventory slot. When setting the filter, the mod prefers to use the item that is in the slot. Otherwise, it uses the item in hand. If the slot is empty and the hand is empty, then no actions are taken, but in the future it makes sense to open the filter selector menu.