### PR TITLE
Clean up and improve the ruler prototype

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -257,72 +257,45 @@ data:extend({
 
    {
       type = "sound",
-      name = "audio-ruler-close-1",
+      name = "audio-ruler-at-bookmark",
       category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/vibraphone-21.ogg",
+      filename = "__base__/sound/programmable-speaker/kit-07.ogg",
       volume = 1,
       preload = true,
    },
 
    {
       type = "sound",
-      name = "audio-ruler-close-2",
+      name = "audio-ruler-horizontal-aligned",
       category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/vibraphone-19.ogg",
+      filename = "__base__/sound/programmable-speaker/plucked-14.ogg",
       volume = 1,
       preload = true,
    },
 
    {
       type = "sound",
-      name = "audio-ruler-diagonal-1",
+      name = "audio-ruler-horizontal-close",
       category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/bass-14.ogg",
+      filename = "__base__/sound/programmable-speaker/plucked-12.ogg",
       volume = 1,
       preload = true,
    },
 
    {
       type = "sound",
-      name = "audio-ruler-diagonal-2",
+      name = "audio-ruler-vertical-aligned",
       category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/bass-12.ogg",
+      filename = "__base__/sound/programmable-speaker/plucked-14.ogg",
       volume = 1,
       preload = true,
    },
 
    {
       type = "sound",
-      name = "audio-ruler-horizontal-1",
+      name = "audio-ruler-vertical-close",
       category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker//vibraphone-14.ogg",
-      volume = 1,
-      preload = true,
-   },
-
-   {
-      type = "sound",
-      name = "audio-ruler-horizontal-2",
-      category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/vibraphone-12.ogg",
-      volume = 1,
-      preload = true,
-   },
-
-   {
-      type = "sound",
-      name = "audio-ruler-vertical-1",
-      category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/vibraphone-14.ogg",
-      volume = 1,
-      preload = true,
-   },
-
-   {
-      type = "sound",
-      name = "audio-ruler-vertical-2",
-      category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/vibraphone-12.ogg",
+      filename = "__base__/sound/programmable-speaker/plucked-12.ogg",
       volume = 1,
       preload = true,
    },

--- a/scripts/fa-utils.lua
+++ b/scripts/fa-utils.lua
@@ -957,40 +957,20 @@ function mod.play_bookmark_alignment_sounds(pindex)
    local diff_y = (math.floor(bookmark_pos.y) - math.floor(cursor_pos.y))
    local dist = util.distance(bookmark_pos, cursor_pos)
 
-   --Print diffs for debug
-   --p.print("diff_x: " .. diff_x .. " | diff_y: " .. diff_y .. " | dist: " .. dist, { volume_modifier = 0 })
-
-   --Bookmark proximity
+   --The cursor is at the bookmark.
    if diff_x == 0 and diff_y == 0 then
-      --Play sound 1
-      p.play_sound({ path = "audio-ruler-close-1" })
-      --elseif math.abs(diff_x) < 2 and math.abs(diff_y) < 2 then
-      --   --Play sound 2
-      --   p.play_sound({ path = "audio-ruler-close-2" })
-   end
-   --Horizontal alignment
-   if diff_x == 0 then
-      --Play sound 1
-      p.play_sound({ path = "audio-ruler-horizontal-1" })
-   elseif math.abs(diff_x) == 1 then
-      --Play sound 2
-      p.play_sound({ path = "audio-ruler-horizontal-2" })
-   end
+      p.play_sound({ path = "audio-ruler-at-bookmark" })
+   -- The cursor is horizontally aligned.
+   elseif diff_x == 0 then
+      p.play_sound({ path = "audio-ruler-horizontal-aligned" })
+   elseif math.abs(diff_x) == 1 and diff_y ~= 0 then
+      p.play_sound({ path = "audio-ruler-horizontal-close" })
    --Vertical alignment
-   if diff_y == 0 then
+   elseif diff_y == 0 then
       --Play sound 1
-      p.play_sound({ path = "audio-ruler-vertical-1" })
+      p.play_sound({ path = "audio-ruler-vertical-aligned" })
    elseif math.abs(diff_y) == 1 then
-      --Play sound 2
-      p.play_sound({ path = "audio-ruler-vertical-2" })
-   end
-   --Diagonal alignment
-   if diff_x ~= 0 and math.abs(diff_x) == math.abs(diff_y) then
-      --Play sound 1
-      p.play_sound({ path = "audio-ruler-diagonal-1" })
-   elseif diff_x ~= 0 and math.abs(math.abs(diff_x) - math.abs(diff_y)) == 1 then
-      --Play sound 2
-      p.play_sound({ path = "audio-ruler-diagonal-2" })
+      p.play_sound({ path = "audio-ruler-vertical-close" })
    end
 end
 


### PR DESCRIPTION
This does a few things:

- No more diagonals. These don't even work with trains because of the curved pieces at each end.
- Switch the sounds around so that being at the bookmark (e.g. via teleporting) is a quiet click-like drum sound, and the ones for aligning elsewhere are not panned.
- Sounds get better names. Kill the entirely meaningless play sound 1 comments.
- Fix up the conditionals so that moving around a bookmark on the 9 adjacent tiles works.


This is now good enough that I probably don't mind it being on.  Problem with the prototype is that since it's always on it really does need to be at least kinda fading into the background.  Hopefully, this does that for people who aren't myself, though I still think that if we are going to release the prototype, we should put it on other keys so people can opt in, even if those keys are suboptimal.  At any rate until we do that, I cannot add cursor skipping support.

Refs #161