### PR TITLE
Changed the link to the wiki at the end of the tutorial

### DIFF
--- a/locale/en/fa-tutorial.cfg
+++ b/locale/en/fa-tutorial.cfg
@@ -1259,6 +1259,6 @@ tutorial-chapter-13-step-25-header=Repeating the last spoken phrase
 tutorial-chapter-13-step-25-detail=You can instruct to repeat the last spoken phrase by pressing "__CONTROL__repeat-last-spoken__". Try this now.
 
 tutorial-chapter-13-step-26-header=More info at the wiki
-tutorial-chapter-13-step-26-detail=While the basics are covered here, there are several more features and tricks and shortcuts that you can find on the Factorio Access Wiki. Here is the link: https://github.com/Crimso777/Factorio-Access/wiki 
+tutorial-chapter-13-step-26-detail=While the basics are covered here, there are several more features and tricks and shortcuts that you can find on the Factorio Access Wiki. Here is the link: https://github.com/factorio-Access/Factorio-Access/wiki 
 
 #python script to convert these to markdown.


### PR DESCRIPTION
Currently, the link to the wiki at the end of the tutorial points to the original version by crimso777.
This changes it to the factorio-access version which is more up to date.
