### PR TITLE
modularize the ruler prototype, and introduce infrastructure to make that easier

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -257,72 +257,45 @@ data:extend({
 
    {
       type = "sound",
-      name = "audio-ruler-close-1",
+      name = "audio-ruler-at-bookmark",
       category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/vibraphone-21.ogg",
+      filename = "__base__/sound/programmable-speaker/kit-07.ogg",
       volume = 1,
       preload = true,
    },
 
    {
       type = "sound",
-      name = "audio-ruler-close-2",
+      name = "audio-ruler-horizontal-aligned",
       category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/vibraphone-19.ogg",
+      filename = "__base__/sound/programmable-speaker/plucked-14.ogg",
       volume = 1,
       preload = true,
    },
 
    {
       type = "sound",
-      name = "audio-ruler-diagonal-1",
+      name = "audio-ruler-horizontal-close",
       category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/bass-14.ogg",
+      filename = "__base__/sound/programmable-speaker/plucked-12.ogg",
       volume = 1,
       preload = true,
    },
 
    {
       type = "sound",
-      name = "audio-ruler-diagonal-2",
+      name = "audio-ruler-vertical-aligned",
       category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/bass-12.ogg",
+      filename = "__base__/sound/programmable-speaker/plucked-14.ogg",
       volume = 1,
       preload = true,
    },
 
    {
       type = "sound",
-      name = "audio-ruler-horizontal-1",
+      name = "audio-ruler-vertical-close",
       category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker//vibraphone-14.ogg",
-      volume = 1,
-      preload = true,
-   },
-
-   {
-      type = "sound",
-      name = "audio-ruler-horizontal-2",
-      category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/vibraphone-12.ogg",
-      volume = 1,
-      preload = true,
-   },
-
-   {
-      type = "sound",
-      name = "audio-ruler-vertical-1",
-      category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/vibraphone-14.ogg",
-      volume = 1,
-      preload = true,
-   },
-
-   {
-      type = "sound",
-      name = "audio-ruler-vertical-2",
-      category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/vibraphone-12.ogg",
+      filename = "__base__/sound/programmable-speaker/plucked-12.ogg",
       volume = 1,
       preload = true,
    },

--- a/scripts/fa-utils.lua
+++ b/scripts/fa-utils.lua
@@ -957,40 +957,20 @@ function mod.play_bookmark_alignment_sounds(pindex)
    local diff_y = (math.floor(bookmark_pos.y) - math.floor(cursor_pos.y))
    local dist = util.distance(bookmark_pos, cursor_pos)
 
-   --Print diffs for debug
-   --p.print("diff_x: " .. diff_x .. " | diff_y: " .. diff_y .. " | dist: " .. dist, { volume_modifier = 0 })
-
-   --Bookmark proximity
+   --The cursor is at the bookmark.
    if diff_x == 0 and diff_y == 0 then
-      --Play sound 1
-      p.play_sound({ path = "audio-ruler-close-1" })
-      --elseif math.abs(diff_x) < 2 and math.abs(diff_y) < 2 then
-      --   --Play sound 2
-      --   p.play_sound({ path = "audio-ruler-close-2" })
-   end
-   --Horizontal alignment
-   if diff_x == 0 then
-      --Play sound 1
-      p.play_sound({ path = "audio-ruler-horizontal-1" })
-   elseif math.abs(diff_x) == 1 then
-      --Play sound 2
-      p.play_sound({ path = "audio-ruler-horizontal-2" })
-   end
+      p.play_sound({ path = "audio-ruler-at-bookmark" })
+   -- The cursor is horizontally aligned.
+   elseif diff_x == 0 then
+      p.play_sound({ path = "audio-ruler-horizontal-aligned" })
+   elseif math.abs(diff_x) == 1 and diff_y ~= 0 then
+      p.play_sound({ path = "audio-ruler-horizontal-close" })
    --Vertical alignment
-   if diff_y == 0 then
+   elseif diff_y == 0 then
       --Play sound 1
-      p.play_sound({ path = "audio-ruler-vertical-1" })
+      p.play_sound({ path = "audio-ruler-vertical-aligned" })
    elseif math.abs(diff_y) == 1 then
-      --Play sound 2
-      p.play_sound({ path = "audio-ruler-vertical-2" })
-   end
-   --Diagonal alignment
-   if diff_x ~= 0 and math.abs(diff_x) == math.abs(diff_y) then
-      --Play sound 1
-      p.play_sound({ path = "audio-ruler-diagonal-1" })
-   elseif diff_x ~= 0 and math.abs(math.abs(diff_x) - math.abs(diff_y)) == 1 then
-      --Play sound 2
-      p.play_sound({ path = "audio-ruler-diagonal-2" })
+      p.play_sound({ path = "audio-ruler-vertical-close" })
    end
 end
 


### PR DESCRIPTION
This is up primarily for debate as I am reasonably confident the ruler module does what it's supposed to, and now that it doesn't screw with bookmarks I will probably be using it more.  As usual this is up early so expect a few patches etc.  Probably not worth aiming for the next release, this is too minor in terms of user-facing changes to be worth the risk and the Discord-proposed solution of just having a key to toggle it is by contrast very simple.

Here, we do a few things. Longer descriptions below:

- Introduce a mechanism for generating unique ids, to make it easier to hand out objects.
- Introduce a mechanism to let modules handle their own global state apart from any other, which both eases the need to initialize and check if a pindex has been used and allows for LuaLS to help us out.
- Introduce a rulers module, and untangle rulers from bookmarks using the keys `ctrl+alt+b` and `shift+alt+b` for the prototype version (these aren't intended to be final; if we have to kill them or move them to somewhere more inconvenient we can. It's a prototype).

# Unique IDs.

The easiest piece to review and to understand is the unique id module, which is more comment than code.  These go 1 2 3 4 etc. every time you call it.  This acts like a singleton counter but should not be used as such!  It is intended to be called from anywhere at any time when one needs a unique table key and just doesn't care.

This solves a couple problems.  First, there's now a way to get a unique id that's "blessed".  What I mean by this is that we won't have to have random empty tables all over or people inventing their own solutions.  Don't worry: we can change how this works, and old ids will simply "phase out" of current saves.  So we aren't stuck on incrementing ints.

The second however is what makes it kind of required.  When you do something like rulers and you haave them in a list and you want to remove one, what you actually need is a reference to the parent table and the key in that table, not the reference to the child.  This is explained more in rulers.lua.  We could make uid() return a table if we really wanted and that would accomplish the same thing, but (usually small) numbers are much more easy to debug than (usually) hex memory addresses.

The usual solution here is uuids, sets of 16 hex chars.  Factorio and Lua together don't offer us a way to do that efficiently.  This is both deterministic and should be reasonably fast.

# Global State Management

The most important thing this PR introduces is global-manager.lua, which encapsulates the following pattern:

- Check if the pindex exists, then fill it out if not.
- Check if the thing under `global.players[pindex]` exists, then fill it out if not.
- Finally do the thing.

The implementation is mostly straightforward if you know how metatables work, but faster because it "magically" (from the external perspective) just always works as if things were fine.  That is, one runs:

```
---@type whatever
local module_state = GlobalManager.declare_global_module("rulers", {
   rulers = {},
})
```

Which is saying "I hereby take over this global key, the default value is this table, and the LuaLS type is above".  Then, one simply writes code without any checks whatsoever: any new pindex automatically gets the default, which also will self-optimize after the first call.  `__index` is only called on missing keys, so all one does is add the key, after which the overhead is exactly equal to not bothering to write any checks at all ever.  Tables are cloned as appropriate, and it is possible also to make defaults off pindex, though that's not used here and whoever first plays with it may have an adventure.  It even saves some pereformancde when looking things up in global by avoiding one of the keys  on all but the first path, though that's not important to us of course (but I'm proud of it anyway and it was free so there)

(this could be used in control.lua arguably. I wouldn't try. That specifically is too tangled).

I would kind of say: not adopting this and keeping the declared variable private, e.g. no "reaching around", is probably a sign of bad code.  One may take that as one will, but rulers.lua demonstrates the complex case of modularity, which we will discuss now.  A side point: cursor.lua whenever it exists should probably be the same way, rather than the whole mod grabbing whatever it needs at the moment.

# Rulers module

This is basically what we had before in terms of function.  From the player perspective it works the same, except that it is now on different keys: `ctrl + alt + b` to save, `shift + alt + b` to clear.

From the internal perspective it's overengineered at first glance, but in actuality it's half comments and type annotations, and the other half is thinking ahead to the world in which we tie these to a bigger object.  The module's design is such that deciding we wanted to tie these to fast travel tomorrow would take...nothing pretty much, the blocker for putting a handle with a fast travel point is that I don't think anyone wants to start figuring out complex UI and categories and all the other blocking things.  But that's fine, this can just sit here, it won't bit rot.  Instead of tying them to fast travel, we tie it to itself, so that the current public interface is going through the public interface we will likely use in future.  This is useful as it bakes the above infrastructure, as well as proving out what I've done about handles.

Handles are the big topic and what all of this is leading up to: a convenient (or better anyway) way to establish relationships between things without having to share internal details.  That is, a handle to a ruler is what allows one to not know anything about the ruler's internals.  A handle, in general, consists of 3 things:

- A function to make one, in this case `upsert_ruler`, which makes one and stashes it in global as a singleton.
- A function on the handle to destroy it when done, because if there is a worse idea than trying to use weak tables with global for object destruction I cannot possibly think what it could be.
- A "class" table and metatable for some boring plumbing.

None of those are something the public interface sees.  instead, `handle:foobar()` and that's it.  So for example in future, the decoupling is that a fast travel point owns a handle and calls things on it for configuration, and it doesn't need to do the dance of pulling out an id and importing a module and and and...

There's two elephants in the room of course.

First is the obvious question--what about my last attempt at abstracting classes?  The answer to that is simple: as noted at the time it is complex and if `:` is good enough for Klonan it is good enough for us.  Secondarily the original UI plan was too complex for what we need and isn't going to come to be.  As a consequence it's currently used in exactly one place.  So, let's kill it.  It'll die off after new UI when circuit network is cleaned up.

Second: isn't this a lot of code to make a handle work?  No, actually.  Just 4 lines:

```
---@class HandleThing
---@function ...
local handle_class = {}
local handle_meta = { __index = handle_class }
script.register_metatable('MyHandle', handle_meta)

function handle_class:do_the_thing()
end
```

Then somewhere later a call to `setmetatable`.
