### PR TITLE
modularize the ruler prototype, and introduce infrastructure to make that easier

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -31,6 +31,7 @@ local fa_warnings = require("scripts.warnings")
 local fa_circuits = require("scripts.circuit-networks")
 local fa_kk = require("scripts.kruise-kontrol-wrapper")
 local fa_quickbar = require("scripts.quickbar")
+local Rulers = require("scripts.rulers")
 
 groups = {}
 entity_types = {}
@@ -1385,7 +1386,7 @@ script.on_event(defines.events.on_player_changed_position, function(event)
          p.selected = nil
       end
       --Play a sound for audio ruler alignment (smooth walk)
-      if players[pindex].in_menu == false then fa_utils.play_bookmark_alignment_sounds(pindex) end
+      if players[pindex].in_menu == false then Rulers.update_from_cursor(pindex) end
    end
 end)
 
@@ -2510,7 +2511,7 @@ function move(direction, pindex)
       end
 
       --Play a sound for audio ruler alignment (telestep moved)
-      if players[pindex].in_menu == false then fa_utils.play_bookmark_alignment_sounds(pindex) end
+      if players[pindex].in_menu == false then Rulers.update_from_cursor(pindex) end
    else
       --New direction: Turn character: --turn
       if players[pindex].walk == WALKING.TELESTEP then
@@ -2565,7 +2566,7 @@ function move(direction, pindex)
       end
 
       --Play a sound for audio ruler alignment (telestep turned)
-      if players[pindex].in_menu == false then fa_utils.play_bookmark_alignment_sounds(pindex) end
+      if players[pindex].in_menu == false then Rulers.update_from_cursor(pindex) end
    end
 
    --Update cursor highlight
@@ -2619,9 +2620,7 @@ function move_key(direction, event, force_single_tile)
    end
 
    --Play a sound for audio ruler alignment (cursor mode moved)
-   if players[pindex].in_menu == false and players[pindex].cursor then
-      fa_utils.play_bookmark_alignment_sounds(pindex)
-   end
+   if players[pindex].in_menu == false and players[pindex].cursor then Rulers.update_from_cursor(pindex) end
 
    --If driving a spidertron in telestep mode, suggest using smooth walking
    if p.vehicle and p.vehicle.type == "spider-vehicle" and players[pindex].walk ~= WALKING.SMOOTH then
@@ -2942,6 +2941,22 @@ script.on_event("cursor-bookmark-clear", function(event)
    players[pindex].cursor_bookmark = nil
    printout("Cleared cursor bookmark", pindex)
    game.get_player(pindex).play_sound({ path = "Close-Inventory-Sound" })
+end)
+
+script.on_event("ruler-save", function(event)
+   pindex = event.player_index
+   if not check_for_player(pindex) then return end
+   local pos = players[pindex].cursor_pos
+   players[pindex].cursor_bookmark = pos
+   Rulers.upsert_ruler(pindex, pos.x, pos.y)
+   printout("Saved ruler at " .. math.floor(pos.x) .. ", " .. math.floor(pos.y), pindex)
+   game.get_player(pindex).play_sound({ path = "Close-Inventory-Sound" })
+end)
+
+script.on_event("ruler-clear", function(event)
+   local pindex = event.player_index
+   Rulers.clear_rulers(pindex)
+   printout("Cleared rulers", pindex)
 end)
 
 script.on_event("type-cursor-target", function(event)

--- a/data.lua
+++ b/data.lua
@@ -257,7 +257,7 @@ data:extend({
 
    {
       type = "sound",
-      name = "audio-ruler-at-bookmark",
+      name = "audio-ruler-at-definition",
       category = "gui-effect",
       filename = "__base__/sound/programmable-speaker/kit-07.ogg",
       volume = 1,
@@ -266,37 +266,19 @@ data:extend({
 
    {
       type = "sound",
-      name = "audio-ruler-horizontal-aligned",
+      name = "audio-ruler-aligned",
       category = "gui-effect",
       filename = "__base__/sound/programmable-speaker/plucked-14.ogg",
-      volume = 1,
+      volume = 0.5,
       preload = true,
    },
 
    {
       type = "sound",
-      name = "audio-ruler-horizontal-close",
+      name = "audio-ruler-close",
       category = "gui-effect",
       filename = "__base__/sound/programmable-speaker/plucked-12.ogg",
-      volume = 1,
-      preload = true,
-   },
-
-   {
-      type = "sound",
-      name = "audio-ruler-vertical-aligned",
-      category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/plucked-14.ogg",
-      volume = 1,
-      preload = true,
-   },
-
-   {
-      type = "sound",
-      name = "audio-ruler-vertical-close",
-      category = "gui-effect",
-      filename = "__base__/sound/programmable-speaker/plucked-12.ogg",
-      volume = 1,
+      volume = 0.5,
       preload = true,
    },
 
@@ -720,6 +702,20 @@ data:extend({
       type = "custom-input",
       name = "cursor-bookmark-clear",
       key_sequence = "CONTROL + SHIFT + B",
+      consuming = "none",
+   },
+
+   {
+      type = "custom-input",
+      name = "ruler-save",
+      key_sequence = "CONTROL + ALT + B",
+      consuming = "none",
+   },
+
+   {
+      type = "custom-input",
+      name = "ruler-clear",
+      key_sequence = "SHIFT + ALT + B",
       consuming = "none",
    },
 

--- a/scripts/global-manager.lua
+++ b/scripts/global-manager.lua
@@ -1,0 +1,81 @@
+--[[
+Functionality for managing global state, in particular splitting it up and
+typing it.
+
+The main entrypoint to this module is declare_global_module, called as:
+
+```
+local module_state = declare_global_module('rulers', {})
+```
+
+Where the second argument is either a table or a function taking a pindex, which
+acts as a default value.  Afterwords, `module_state[pindex]` invisibly and
+magically refers to `global.players[pindex].modulename`, in a slightly more
+efficient way than the longer expression, and definitely in a more efficient way
+than checking for a player's presence before every use.  Any pindex which is not
+present gets a copy of the default value, or if it is a function, whatever the
+function returns.
+
+The last point of this module is that it may be used with LuaLS, unlike the
+global constant itself.  One may type the global state for a module like this:
+
+```
+---@class MyClass
+---@field my_field String does cool stuff
+
+---@type table<number, MyClass>
+local module_state = ...
+```
+
+Enabling both autocomplete and type checks.
+]]
+
+local mod = {}
+
+---@param module_name string
+---@param default_value any
+---@returns any
+function mod.declare_global_module(module_name, default_value)
+   assert(default_value ~= nil, "Default values of nil can't be put in a table as values")
+
+   local default_fn = default_value
+   if type(default_fn) == "table" then
+      default_fn = function(_pindex)
+         return table.deepcopy(default_value)
+      end
+   elseif type(default_fn) ~= "function" then
+      default_fn = function()
+         return default_value
+      end
+   end
+
+   -- Ensure that the players array itself is present.
+   if not global.players then global.players = {} end
+
+   local meta = {}
+
+   function meta:__newindex(pindex, nv)
+      -- Gets picked up by `__index` below.
+      global.players[pindex][module_name] = nv
+   end
+
+   function meta:__index(pindex)
+      local possible = global.players[pindex][module_name]
+      if not possible then possible = default_fn(pindex) end
+
+      -- Checked by the above assert and also LuaLS, but this isn't a critical
+      -- path and it doesn't hurt.
+      assert(possible, "Somehow, we got a default value of NIL")
+
+      -- After this, the table no longer calls this metamethod.
+      self[pindex] = possible
+      global.players[pindex][module_name] = possible
+      return possible
+   end
+
+   local ret = {}
+   setmetatable(ret, meta)
+   return ret
+end
+
+return mod

--- a/scripts/rulers.lua
+++ b/scripts/rulers.lua
@@ -1,0 +1,235 @@
+--[[
+Audio rulers.
+
+A ruler triggers when the cursor touches or crosses its boundaries and plays a
+sound.  Right now there is one ruler per player and no interaction with cursor
+skipping.  Both of these will change later.  For the sake of the prototype,
+players place a ruler with alt+b and clear with alt+shift+b.  If they want to
+also have a bookmark there, we make them do so themselves.
+
+We return an opaque handle which may safely be stored in global, and we (for
+now) use that ourselves.  The long term plan as of 2024-08-02 is to integrate
+this functionality with fast travel, so in future a handle will simply go live
+over there with fast travel points.
+]]
+local GlobalManager = require("scripts.global-manager")
+local uid = require("scripts.uid").uid
+
+local mod = {}
+
+---@class fa.Ruler
+---@field x number
+---@field y number
+
+---@class fa.RulerGlobalState
+---@field rulers fa.Ruler[]
+---@field handle fa.RulerHandle? temporary, see comments below on how handles work.
+
+-- How far from the ruler do we give the boundary sound?
+local RULER_SIDE_DIST = 1
+
+--- When using a handle to a ruler which was deleted, this message is thrown.
+local DELETED_MSG = "Attempt to use a ruler handle which was previously deleted"
+
+---@type table<number, fa.RulerGlobalState>
+local module_state = GlobalManager.declare_global_module("rulers", {
+   -- For now only ever holds one; this is future proofing.
+   rulers = {},
+})
+
+--[[
+As promised in uid.lua, an explanation of the handle:
+
+- Rulers are in a table<number, Ruler>
+- Handles hold a pindex (so we know which player it was for), the reference to
+  the table (so that we need not take the overhead of looking it up, and so that
+  code is simpler) and this unique id.
+- When deleting, the handle clears out it's table reference, then uses the
+  unique id to go   delete the ruler from global.
+- Then the ruler handle switches itself off effectively by just asserting that
+  the table reference is still there.  This gives users of the API a clear
+  message if they are trying to use rulers they deleted by throwing an error,
+  rather than let them hold a reference this module knows nothing about.
+
+For now this is a demonstrational prototype, which means that all handles do is
+delete.  Once they get integrated into fast travel, however, they will need to
+support being reconfigured--functions on this "class" is where that belongs.
+
+In practice right now it is one ruler per player; the handle is stashed in the
+`handle` field of our global per-player state.
+
+You can think of this like a Java class except with some ceremony that lets it
+live in global.
+]]
+---@class fa.RulerHandle
+---@field pindex number
+---@field id number
+---@field ruler fa.Ruler?  Nil if deleted already.
+local handle_class = {}
+local handle_meta = { __index = handle_class }
+
+script.register_metatable("RulerHandle", handle_meta)
+
+function handle_class:delete()
+   assert(self.ruler, DELETED_MSG)
+   module_state[self.pindex].rulers[self.id] = nil
+   self.ruler = nil
+end
+
+-- Return the manhattan distance from a point.
+--
+-- Imagine a right triangle.  The manhattan distance between the two non-right
+-- angles is the length of the other two sides. E.g. "3 blocks east and 2 blocks
+-- north".
+--
+-- This, slightly cleaned up and more clearly explained, is also a good function
+-- for a math helper module in future.  It solves a great number of alignment
+-- problems which we have been solving using extremely complex if trees.
+--
+---@param pos_x number
+---@param pos_y number
+---@param ruler_x number
+---@param ruler_y number
+---@returns number, numbre
+local function manhattan(pos_x, pos_y, ruler_x, ruler_y)
+   return ruler_x - pos_x, ruler_y - pos_y
+end
+
+---@enum fa.RulerAlignmentResult
+local ALIGNMENT = {
+   NOT_ALIGNED = 0,
+   CLOSE = 1,
+
+   -- The player is on the centerline.
+   CENTERED = 2,
+
+   -- The player is at the point which defines the ruler.
+   AT_DEFINITION = 3,
+
+   -- The cursor is on a corner around the center where the two alignments meet.
+   ON_AMBIGUOUS_CORNER = 4,
+}
+
+---@returns fa.RulerAlignmentResult
+local function determine_alignment(pos_x, pos_y, ruler_x, ruler_y)
+   local m_x, m_y = manhattan(pos_x, pos_y, ruler_x, ruler_y)
+
+   local x_aligned = math.abs(m_x) <= RULER_SIDE_DIST
+   local y_aligned = math.abs(m_y) <= RULER_SIDE_DIST
+
+   -- Easy and common case first. This helps performance in future when we look
+   -- at cursor skipping modes, since it executes over 99% of the time.
+   if not (x_aligned or y_aligned) then return ALIGNMENT.NOT_ALIGNED end
+
+   -- While the next-most common case is the edges, we are at the point where we
+   -- do not need to care about that since the above is the 99% case.  First we
+   -- will determine if the player is at the center.
+   if m_x == 0 and m_y == 0 then return ALIGNMENT.AT_DEFINITION end
+
+   -- We may use an un-aligned direction to determine which part of the ruler
+   -- the player is on.  If both are aligned and nonzero, then it's an ambiguous
+   -- corner.
+   if x_aligned and y_aligned and m_x > 0 and m_y > 0 then return ALIGNMENT.ON_AMBIGUOUS_CORNER end
+
+   if m_x == 0 or m_y == 0 then return ALIGNMENT.CENTERED end
+
+   return ALIGNMENT.CLOSE
+end
+
+-- Settings for which sounds to use for each alignment type. Nil means don't
+-- play anything (e.g. just leave it out of the table)
+local ALIGNMENT_SOUNDS = {
+   [ALIGNMENT.AT_DEFINITION] = {
+      path = "audio-ruler-at-definition",
+   },
+   [ALIGNMENT.ON_AMBIGUOUS_CORNER] = {
+      path = "audio-ruler-close",
+   },
+   [ALIGNMENT.CLOSE] = {
+      path = "audio-ruler-close",
+   },
+   [ALIGNMENT.CENTERED] = {
+      path = "audio-ruler-aligned",
+   },
+}
+
+local function play_ruler_alignment(pindex, alignment)
+   local s = ALIGNMENT_SOUNDS[alignment]
+   local p = game.get_player(pindex)
+   if not p then game.print("No player with pindex " .. tonumber(pindex)) end
+
+   -- Nothing to do, not aligned.
+   if not s then return end
+
+   p.play_sound(s)
+end
+
+-- If a ruler is present for this player, destroy it.  Then make a new one.
+---@param pindex number
+---@param x number
+---@param y number
+---@returns fa.RulerHandle
+function mod.upsert_ruler(pindex, x, y)
+   x = math.floor(x)
+   y = math.floor(y)
+
+   local state = module_state[pindex]
+   if state.handle ~= nil then state.handle:delete() end
+   assert(not next(module_state[pindex].rulers), "The ruler did not delete for player " .. tonumber(pindex))
+   local id = uid()
+   state.rulers[id] = {
+      x = x,
+      y = y,
+   }
+
+   local handle = {
+      pindex = pindex,
+      id = id,
+      ruler = state.rulers[id],
+   }
+
+   setmetatable(handle, handle_meta)
+   state.handle = handle
+   return handle
+end
+
+-- Called every time the player moves their viewpoint.
+function handle_class:play_if_needed(x, y)
+   assert(self.ruler, DELETED_MSG)
+
+   x = math.floor(x)
+   y = math.floor(y)
+
+   local alignment = determine_alignment(x, y, self.ruler.x, self.ruler.y)
+   play_ruler_alignment(self.pindex, alignment)
+end
+
+-- Must be called every time the "viewpoint" for a player moves, e.g. cursor,
+-- walking, whatever.  Should be passed the coords of the tile.  Arguments are floored.
+function mod.on_viewpoint_moved(pindex, x, y)
+   -- For now we just tell the ruler handle to play if it has to.
+   if module_state[pindex].handle then module_state[pindex].handle:play_if_needed(x, y) end
+end
+
+function mod.clear_rulers(pindex)
+   local state = module_state[pindex]
+   if state.handle then
+      state.handle:delete()
+      state.handle = nil
+      assert(not next(state.rulers), "The ruler failed to delete for " .. pindex)
+   end
+end
+
+-- Soorta legacy: work out the cursor position of the player and use that as the
+-- "viewpoint".
+--
+-- Sorta legacy because I (ahicks) think that we're going to havve to eventually
+-- move away from the cursor and the walking player being the same thing,
+-- especially with being able to walk in cursor mode on the horizon.  But it's
+-- fine to use it for now.
+function mod.update_from_cursor(pindex)
+   local cur = players[pindex].cursor_pos
+   mod.on_viewpoint_moved(pindex, cur.x, cur.y)
+end
+
+return mod

--- a/scripts/uid.lua
+++ b/scripts/uid.lua
@@ -1,0 +1,24 @@
+--[[
+Unique ids
+
+Sometimes it is very useful to generate ids which are unique per save.  This is
+used for example in rulers.
+
+At first it may seem that one might simply use tables.  This works for
+everything but deletion.  Usually a table is one level too deep for removal.  By
+using an integral id, removal itself becomes easy.  See rulers.lua for the
+pattern; that was left with extra comments for the sake of being able to see the
+why of it.
+
+]]
+
+local mod = {}
+
+---@returns number
+function mod.uid()
+   if not global.id_counter then global.id_counter = 0 end
+   global.id_counter = global.id_counter + 1
+   return global.id_counter
+end
+
+return mod


### PR DESCRIPTION
This is up primarily for debate as I am reasonably confident the ruler module does what it's supposed to, and now that it doesn't screw with bookmarks I will probably be using it more.  As usual this is up early so expect a few patches etc.  Probably not worth aiming for the next release, this is too minor in terms of user-facing changes to be worth the risk and the Discord-proposed solution of just having a key to toggle it is by contrast very simple.

Here, we do a few things. Longer descriptions below:

- Introduce a mechanism for generating unique ids, to make it easier to hand out objects.
- Introduce a mechanism to let modules handle their own global state apart from any other, which both eases the need to initialize and check if a pindex has been used and allows for LuaLS to help us out.
- Introduce a rulers module, and untangle rulers from bookmarks using the keys `ctrl+alt+b` and `shift+alt+b` for the prototype version (these aren't intended to be final; if we have to kill them or move them to somewhere more inconvenient we can. It's a prototype).

# Unique IDs.

The easiest piece to review and to understand is the unique id module, which is more comment than code.  These go 1 2 3 4 etc. every time you call it.  This acts like a singleton counter but should not be used as such!  It is intended to be called from anywhere at any time when one needs a unique table key and just doesn't care.

This solves a couple problems.  First, there's now a way to get a unique id that's "blessed".  What I mean by this is that we won't have to have random empty tables all over or people inventing their own solutions.  Don't worry: we can change how this works, and old ids will simply "phase out" of current saves.  So we aren't stuck on incrementing ints.

The second however is what makes it kind of required.  When you do something like rulers and you haave them in a list and you want to remove one, what you actually need is a reference to the parent table and the key in that table, not the reference to the child.  This is explained more in rulers.lua.  We could make uid() return a table if we really wanted and that would accomplish the same thing, but (usually small) numbers are much more easy to debug than (usually) hex memory addresses.

The usual solution here is uuids, sets of 16 hex chars.  Factorio and Lua together don't offer us a way to do that efficiently.  This is both deterministic and should be reasonably fast.

# Global State Management

The most important thing this PR introduces is global-manager.lua, which encapsulates the following pattern:

- Check if the pindex exists, then fill it out if not.
- Check if the thing under `global.players[pindex]` exists, then fill it out if not.
- Finally do the thing.

The implementation is mostly straightforward if you know how metatables work, but faster because it "magically" (from the external perspective) just always works as if things were fine.  That is, one runs:

```
---@type whatever
local module_state = GlobalManager.declare_global_module("rulers", {
   rulers = {},
})
```

Which is saying "I hereby take over this global key, the default value is this table, and the LuaLS type is above".  Then, one simply writes code without any checks whatsoever: any new pindex automatically gets the default, which also will self-optimize after the first call.  `__index` is only called on missing keys, so all one does is add the key, after which the overhead is exactly equal to not bothering to write any checks at all ever.  Tables are cloned as appropriate, and it is possible also to make defaults off pindex, though that's not used here and whoever first plays with it may have an adventure.  It even saves some pereformancde when looking things up in global by avoiding one of the keys  on all but the first path, though that's not important to us of course (but I'm proud of it anyway and it was free so there)

(this could be used in control.lua arguably. I wouldn't try. That specifically is too tangled).

I would kind of say: not adopting this and keeping the declared variable private, e.g. no "reaching around", is probably a sign of bad code.  One may take that as one will, but rulers.lua demonstrates the complex case of modularity, which we will discuss now.  A side point: cursor.lua whenever it exists should probably be the same way, rather than the whole mod grabbing whatever it needs at the moment.

# Rulers module

This is basically what we had before in terms of function.  From the player perspective it works the same, except that it is now on different keys: `ctrl + alt + b` to save, `shift + alt + b` to clear.

From the internal perspective it's overengineered at first glance, but in actuality it's half comments and type annotations, and the other half is thinking ahead to the world in which we tie these to a bigger object.  The module's design is such that deciding we wanted to tie these to fast travel tomorrow would take...nothing pretty much, the blocker for putting a handle with a fast travel point is that I don't think anyone wants to start figuring out complex UI and categories and all the other blocking things.  But that's fine, this can just sit here, it won't bit rot.  Instead of tying them to fast travel, we tie it to itself, so that the current public interface is going through the public interface we will likely use in future.  This is useful as it bakes the above infrastructure, as well as proving out what I've done about handles.

Handles are the big topic and what all of this is leading up to: a convenient (or better anyway) way to establish relationships between things without having to share internal details.  That is, a handle to a ruler is what allows one to not know anything about the ruler's internals.  A handle, in general, consists of 3 things:

- A function to make one, in this case `upsert_ruler`, which makes one and stashes it in global as a singleton.
- A function on the handle to destroy it when done, because if there is a worse idea than trying to use weak tables with global for object destruction I cannot possibly think what it could be.
- A "class" table and metatable for some boring plumbing.

None of those are something the public interface sees.  instead, `handle:foobar()` and that's it.  So for example in future, the decoupling is that a fast travel point owns a handle and calls things on it for configuration, and it doesn't need to do the dance of pulling out an id and importing a module and and and...

There's two elephants in the room of course.

First is the obvious question--what about my last attempt at abstracting classes?  The answer to that is simple: as noted at the time it is complex and if `:` is good enough for Klonan it is good enough for us.  Secondarily the original UI plan was too complex for what we need and isn't going to come to be.  As a consequence it's currently used in exactly one place.  So, let's kill it.  It'll die off after new UI when circuit network is cleaned up.

Second: isn't this a lot of code to make a handle work?  No, actually.  Just 4 lines:

```
---@class HandleThing
---@function ...
local handle_class = {}
local handle_meta = { __index = handle_class }
script.register_metatable('MyHandle', handle_meta)

function handle_class:do_the_thing()
end
```

Then somewhere later a call to `setmetatable`.
