### PR TITLE
Clean up entity selection

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -572,8 +572,9 @@ end
 --Used when a tile has multiple overlapping entities. Reads out the next entity.
 function tile_cycle(pindex)
    local ent = get_next_ent_at_tile(pindex)
-   if ent then
+   if ent and ent.valid then
       printout(fa_info.ent_info(pindex, ent, ""), pindex)
+      game.get_player(pindex).selected = ent
    else
       printout(players[pindex].tile.tile, pindex)
    end

--- a/control.lua
+++ b/control.lua
@@ -170,19 +170,6 @@ local function iterate_selected_ents(pindex)
    return next_fn, nil, nil
 end
 
---Returns the first useful ent in the player tile. 
---Useful meaning not the player character or a corpse or a flying robot.
---Unused function for now.
-function get_first_useful_ent(pindex)
-   for ent in iterate_selected_ents(pindex) do
-      local bad = ent.type == "logistic-robot"
-         or ent.type == "construction-robot"
-         or ent.type == "combat-robot"
-         or ent.type == "corpse"
-      if not bad then return ent end
-   end
-end
-
 --???
 function prune_item_groups(array)
    if #groups == 0 then

--- a/control.lua
+++ b/control.lua
@@ -151,6 +151,8 @@ function ent_is_primary(ent, pindex)
       and ent.type ~= "construction-robot"
       and ent.type ~= "combat-robot"
       and ent.type ~= "corpse"
+      and ent.type ~= "rocket-silo-rocket-shadow"
+      and ent.type ~= "resource"
       and (ent.type ~= "character" or ent.player ~= pindex)
 end
 

--- a/control.lua
+++ b/control.lua
@@ -5721,7 +5721,7 @@ function do_multi_stack_transfer(ratio, pindex)
       local offset = 1
       if players[pindex].building.recipe_list ~= nil then offset = offset + 1 end
       if players[pindex].building.sector_name == "player inventory from building" then
-         game.print("path 3b")
+         game.get_player(pindex).print("(inventory transfer issue?)", {volume_modifier=0})
          --This is the section where we move from the player to the building.
          local item_name = ""
          local stack = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
@@ -5734,10 +5734,11 @@ function do_multi_stack_transfer(ratio, pindex)
             ratio = ratio,
          })
 
-         if full then table.insert(result, "Inventory full or not applicable, ") end
          if table_size(moved) == 0 then
+            if full then table.insert(result, "Inventory full or not applicable, ") end
             table.insert(result, { "access.placed-nothing" })
          else
+            if full then table.insert(result, "Partial success, ") end
             game.get_player(pindex).play_sound({ path = "utility/inventory_move" })
             local item_list = { "" }
             local other_items = 0

--- a/control.lua
+++ b/control.lua
@@ -678,10 +678,6 @@ end
 --Re-checks the cursor tile and indexes the entities on it, returns a boolean on whether it is successful.
 function refresh_player_tile(pindex)
    local surf = game.get_player(pindex).surface
-   --local search_area = {{x=-0.5,y=-0.5},{x=0.29,y=0.29}}
-   --local search_center = players[pindex].cursor_pos
-   --search_area[1]=add_position(search_area[1],search_center)
-   --search_area[2]=add_position(search_area[2],search_center)
    local c_pos = players[pindex].cursor_pos
    if math.floor(c_pos.x) == math.ceil(c_pos.x) then c_pos.x = c_pos.x - 0.01 end
    if math.floor(c_pos.y) == math.ceil(c_pos.y) then c_pos.y = c_pos.y - 0.01 end
@@ -701,7 +697,10 @@ function refresh_player_tile(pindex)
    for i, remnant in ipairs(remnants) do
       table.insert(players[pindex].tile.ents, remnant)
    end
-   players[pindex].tile.ent_index = #players[pindex].tile.ents == 0 and 0 or 1
+   players[pindex].tile.ent_index = 1
+   if #players[pindex].tile.ents == 0 then
+      players[pindex].tile.ent_index = 0
+   end
    if
       not (
          pcall(function()

--- a/control.lua
+++ b/control.lua
@@ -201,6 +201,13 @@ function get_next_ent_at_tile(pindex)
       end
    end
 
+   --Return nil to get the tile info instead
+   if last_returned_index ~= 0 then
+      players[pindex].tile.ent_index = 0
+      players[pindex].tile.last_returned_index = 0
+      return nil
+   end
+
    --Attempt to find the next ent (start to init)
    for i = 1, init_index - 1, 1 do
       current = ents[i]

--- a/control.lua
+++ b/control.lua
@@ -176,6 +176,28 @@ function sort_ents_by_primary_first(ents)
    end)
 end
 
+--Get the first entity at a tile 
+--The entity list is sorted to have primary entities first, so a primary entity is expected.
+function get_first_ent_at_tile(pindex)
+   local ents = players[pindex].tile.ents
+
+   --Return nil for an empty ents list
+   if ents == nil or #ents == 0 then return nil end
+
+   --Attempt to find the next ent (init to end)
+   for i = 1, #ents, 1 do
+      current = ents[i]
+      if current and current.valid then
+         players[pindex].tile.ent_index = i
+         players[pindex].tile.last_returned_index = i
+         return current
+      end
+   end
+
+   --By this point there are no valid ents
+   return nil
+end
+
 --Get the next entity at this tile and note its index.
 --The tile entity list is already sorted such that primary ents are listed first.
 function get_next_ent_at_tile(pindex)

--- a/control.lua
+++ b/control.lua
@@ -5721,7 +5721,7 @@ function do_multi_stack_transfer(ratio, pindex)
       local offset = 1
       if players[pindex].building.recipe_list ~= nil then offset = offset + 1 end
       if players[pindex].building.sector_name == "player inventory from building" then
-         game.get_player(pindex).print("(inventory transfer issue?)", {volume_modifier=0})
+         game.get_player(pindex).print("(inventory transfer issue?)", { volume_modifier = 0 })
          --This is the section where we move from the player to the building.
          local item_name = ""
          local stack = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]

--- a/control.lua
+++ b/control.lua
@@ -170,6 +170,19 @@ local function iterate_selected_ents(pindex)
    return next_fn, nil, nil
 end
 
+--Returns the first useful ent in the player tile. 
+--Useful meaning not the player character or a corpse or a flying robot.
+--Unused function for now.
+function get_first_useful_ent(pindex)
+   for ent in iterate_selected_ents(pindex) do
+      local bad = ent.type == "logistic-robot"
+         or ent.type == "construction-robot"
+         or ent.type == "combat-robot"
+         or ent.type == "corpse"
+      if not bad then return ent end
+   end
+end
+
 --???
 function prune_item_groups(array)
    if #groups == 0 then

--- a/control.lua
+++ b/control.lua
@@ -154,30 +154,29 @@ function ent_is_primary(ent, pindex)
       and (ent.type ~= "character" or ent.player ~= pindex)
 end
 
---on iteration: return the next useful ent. If the list end is reached, return the next extra ent. Else circle back.
-
+-- Sorts a list of entities by bringing primary entities to the start
+function sort_ents_by_primary_first(ents)
+   table.sort(ents, function(a, b)
+      -- Return false if either are invalid
+      if a == nil or a.valid == false then return false end
       if b == nil or b.valid == false then return false end
 
       -- Check if primary
-       local a_is_primary = ent_is_primary(a, pindex)
-       local b_is_primary = ent_is_primary(b, pindex)
+      local a_is_primary = ent_is_primary(a, pindex)
+      local b_is_primary = ent_is_primary(b, pindex)
 
-       -- Both or none are primary
-       if a_is_primary == b_is_primary then
-           return false
-       end
+      -- Both or none are primary
+      if a_is_primary == b_is_primary then return false end
 
-       -- a is primary while b is not
-       if a_is_primary then
-           return true
-       end
+      -- a is primary while b is not
+      if a_is_primary then return true end
 
-       -- b is primary while a is not
-       return false
+      -- b is primary while a is not
+      return false
    end)
 end
 
---Get the next entity at this tile and note its index. 
+--Get the next entity at this tile and note its index.
 --The tile entity list is already sorted such that primary ents are listed first.
 function get_next_ent_at_tile(pindex)
    local ents = players[pindex].tile.ents
@@ -760,9 +759,7 @@ function refresh_player_tile(pindex)
       table.insert(players[pindex].tile.ents, remnant)
    end
    players[pindex].tile.ent_index = 1
-   if #players[pindex].tile.ents == 0 then
-      players[pindex].tile.ent_index = 0
-   end
+   if #players[pindex].tile.ents == 0 then players[pindex].tile.ent_index = 0 end
    players[pindex].tile.last_returned_index = 0
    if
       not (

--- a/control.lua
+++ b/control.lua
@@ -132,20 +132,20 @@ function get_selected_ent_deprecated(pindex, ent_no)
    local ent
    local ent_no = ent_no or 1
    while true do
-      if tile.index > #tile.ents then tile.index = #tile.ents end
-      if tile.index == 0 then return nil end
-      ent = tile.ents[tile.index]
-      if not ent then print(serpent.line(tile.ents), tile.index, ent) end
+      if tile.ent_index > #tile.ents then tile.ent_index = #tile.ents end
+      if tile.ent_index == 0 then return nil end
+      ent = tile.ents[tile.ent_index]
+      if not ent then print(serpent.line(tile.ents), tile.ent_index, ent) end
       if ent.valid and (ent.type ~= "character" or players[pindex].cursor or ent.player ~= pindex) then
          ent_no = ent_no - 1
       end
       if ent_no <= 0 then return ent end
-      table.remove(tile.ents, tile.index)
+      table.remove(tile.ents, tile.ent_index)
    end
 end
 
 --- Produce an iterator over all valid entities for a player's selected tile,
---  filtering out the player themselves.
+--  while filtering out the player themselves.
 local function iterate_selected_ents(pindex)
    local tile = players[pindex].tile
    local ents = tile.ents
@@ -159,11 +159,9 @@ local function iterate_selected_ents(pindex)
          local ent = ents[i]
          i = i + 1
 
-         if not ent.valid then goto continue end
-
-         if ent.type ~= "character" or ent.player ~= pindex then return ent end
-
-         ::continue::
+         if ent and ent.valid then
+            if ent.type ~= "character" or ent.player ~= pindex then return ent end
+         end
       end
 
       return nil
@@ -491,8 +489,8 @@ end
 --Checks the cursor tile for a new entity and reads out ent info. Used when a tile has multiple overlapping entities.
 function tile_cycle(pindex)
    local tile = players[pindex].tile
-   tile.index = tile.index + 1
-   if tile.index > #tile.ents then tile.index = 0 end
+   tile.ent_index = tile.ent_index + 1
+   if tile.ent_index > #tile.ents then tile.ent_index = 0 end
    local ent = get_selected_ent_deprecated(pindex)
    if ent then
       printout(fa_info.ent_info(pindex, ent, ""), pindex)
@@ -690,7 +688,7 @@ function refresh_player_tile(pindex)
    for i, remnant in ipairs(remnants) do
       table.insert(players[pindex].tile.ents, remnant)
    end
-   players[pindex].tile.index = #players[pindex].tile.ents == 0 and 0 or 1
+   players[pindex].tile.ent_index = #players[pindex].tile.ents == 0 and 0 or 1
    if
       not (
          pcall(function()

--- a/control.lua
+++ b/control.lua
@@ -121,29 +121,6 @@ function call_to_check_ghost_rails(pindex)
    fa_rails.check_ghost_rail_planning_results(pindex)
 end
 
--- Deprecated. Do not use.
---
--- This function used to be called get_selected_ent and implied that it would
--- simply read entities off a tile.  What it actually did was try to shuffle
--- entities round to remove players from a cache permanently, with emphasis on
--- try.  The code below has a large number of failure conditions.
-function get_selected_ent_deprecated(pindex, ent_no)
-   local tile = players[pindex].tile
-   local ent
-   local ent_no = ent_no or 1
-   while true do
-      if tile.ent_index > #tile.ents then tile.ent_index = #tile.ents end
-      if tile.ent_index == 0 then return nil end
-      ent = tile.ents[tile.ent_index]
-      if not ent then print(serpent.line(tile.ents), tile.ent_index, ent) end
-      if ent.valid and (ent.type ~= "character" or players[pindex].cursor or ent.player ~= pindex) then
-         ent_no = ent_no - 1
-      end
-      if ent_no <= 0 then return ent end
-      table.remove(tile.ents, tile.ent_index)
-   end
-end
-
 --Define primary ents, which are ents that show up first when reading tiles.
 --Notably, the definition is done by listing which types count as secondary.
 function ent_is_primary(ent, pindex)
@@ -178,7 +155,7 @@ function sort_ents_by_primary_first(ents)
    end)
 end
 
---Get the first entity at a tile 
+--Get the first entity at a tile
 --The entity list is sorted to have primary entities first, so a primary entity is expected.
 function get_first_ent_at_tile(pindex)
    local ents = players[pindex].tile.ents

--- a/control.lua
+++ b/control.lua
@@ -215,6 +215,8 @@ function get_next_ent_at_tile(pindex)
    end
 
    --By this point there are no valid ents
+   players[pindex].tile.ent_index = 0
+   players[pindex].tile.last_returned_index = 0
    return nil
 end
 
@@ -566,7 +568,7 @@ function tile_cycle(pindex)
    if ent then
       printout(fa_info.ent_info(pindex, ent, ""), pindex)
    else
-      printout(tile.tile, pindex)
+      printout(players[pindex].tile.tile, pindex)
    end
 end
 

--- a/scripts/fa-utils.lua
+++ b/scripts/fa-utils.lua
@@ -352,9 +352,11 @@ function mod.get_entity_part_at_cursor(pindex)
 
    --First check if there is an entity at the cursor
    if #ents > 0 then
-      --Choose something else if ore is selected
+      --Prefer the selected ent
       local preferred_ent = p.selected
-      if preferred_ent == nil or preferred_ent.valid == false then return nil end
+      --Otherwise check for other ents at the cursor
+      if preferred_ent == nil or preferred_ent.valid == false then preferred_ent = get_first_ent_at_tile(pindex) end
+      if preferred_ent == nil or preferred_ent.valid == false then return "unknown location" end
 
       --Report which part of the entity the cursor covers.
       rendering.draw_circle({

--- a/scripts/fa-utils.lua
+++ b/scripts/fa-utils.lua
@@ -343,16 +343,7 @@ function mod.get_entity_part_at_cursor(pindex)
    local p = game.get_player(pindex)
    local x = players[pindex].cursor_pos.x
    local y = players[pindex].cursor_pos.y
-   local excluded_names = {
-      "character",
-      "flying-text",
-      "highlight-box",
-      "combat-robot",
-      "logistic-robot",
-      "construction-robot",
-      "rocket-silo-rocket-shadow",
-   }
-   local ents = p.surface.find_entities_filtered({ position = { x = x, y = y }, name = excluded_names, invert = true })
+   local ents = players[pindex].tile.ents
    local north_same = false
    local south_same = false
    local east_same = false
@@ -362,12 +353,8 @@ function mod.get_entity_part_at_cursor(pindex)
    --First check if there is an entity at the cursor
    if #ents > 0 then
       --Choose something else if ore is selected
-      local preferred_ent = ents[1]
-      for i, ent in ipairs(ents) do
-         if ent.valid and ent.type ~= "resource" then preferred_ent = ent end
-      end
-      p.selected = preferred_ent
-      --TODO cleanup here with get_selected_ent_deprecated or the such
+      local preferred_ent = p.selected
+      if preferred_ent == nil or preferred_ent.valid == false then return nil end
 
       --Report which part of the entity the cursor covers.
       rendering.draw_circle({

--- a/scripts/graphics.lua
+++ b/scripts/graphics.lua
@@ -423,13 +423,21 @@ function mod.draw_cursor_highlight(pindex, ent, box_type, skip_mouse_movement)
    if h_box ~= nil and h_box.valid then h_box.destroy() end
    if h_tile ~= nil and rendering.is_valid(h_tile) then rendering.destroy(h_tile) end
 
+   --Skip drawing if hide cursor is enabled
    if players[pindex].hide_cursor then
       players[pindex].cursor_ent_highlight_box = nil
       players[pindex].cursor_tile_highlight_box = nil
       return
    end
 
-   if ent ~= nil and ent.valid and ent.name ~= "highlight-box" and ent.type ~= "flying-text" then
+   --Draw highlight box
+   if
+      ent ~= nil
+      and ent.valid
+      and ent.name ~= "highlight-box"
+      and ent.type ~= "flying-text"
+      and (p.selected == nil or p.selected.valid == false)
+   then
       h_box = p.surface.create_entity({
          name = "highlight-box",
          force = "neutral",
@@ -443,12 +451,6 @@ function mod.draw_cursor_highlight(pindex, ent, box_type, skip_mouse_movement)
          h_box.highlight_box_type = box_type
       else
          h_box.highlight_box_type = "entity"
-      end
-
-      --Select the entity at the cursor position
-      --TODO maybe clean this up with get_selected_ent_deprecated
-      if players[pindex].cursor or (p.character ~= nil and ent.unit_number ~= p.character.unit_number) then
-         p.selected = ent
       end
    end
 

--- a/scripts/kruise-kontrol-wrapper.lua
+++ b/scripts/kruise-kontrol-wrapper.lua
@@ -33,7 +33,7 @@ function mod.activate_kk(pindex)
       -- we must duplicate a bit of logic since the mouse is not on our side; FA
       -- has its own idea of selections.
       refresh_player_tile(pindex)
-      local target = get_selected_ent_deprecated(pindex)
+      local target = get_first_ent_at_tile(pindex)
 
       -- Okay, but what other edge cases can we find?  Turns out that, again, KK
       -- doesn't work if there's a blueprint in the player's hand.  This one is

--- a/scripts/scanner.lua
+++ b/scripts/scanner.lua
@@ -715,6 +715,7 @@ function mod.list_index(pindex)
          end
          --Select the northwest corner of the entity
          players[pindex].cursor_pos = fa_utils.get_ent_northwest_corner_position(ent)
+         p.selected = ent
          --Select spaceship wreck pieces from the center because of their irregular shapes
          local check = ent.name
          local a = string.find(check, "spaceship")


### PR DESCRIPTION
Finishes the work started with #182, which is to remove the deprecated entity selection function and to generally clean up entity selection. The new functions use the player tile entity list but they do not modify it apart from sorting it immediately upon creating it.

Changes:
- Cleaned up `refresh_player_tile`
- Renamed `tile.index` to `tile.ent_index` for improved clarity
- Defined secondary ents as those we throw to the end when reading a tile. These include flying robots of all sorts, your own player character, all corpse types (remnants), rocket shadows, and resource entities.
- Therefore defined primary ents as those that are not secondary.
- Added function that sorts an entity list such that primary ents come first.
- `refresh_player_tile` now sorts the scan result list accordingly.
- Newly added `get_next_ent_at_tile` simply iterates along the sorted list.
- Newly added `get_first_ent_at_tile` simply gets the topmost primary ent. 
- `get_first_ent_at_tile` replaces `get_selected_ent_deprecated`. Fetching the first primary ent is enough because primary ents very rarely or never overlap each other.
- Reworked `tile_cycle` accordingly. It now properly selects the new ent when you cycle to it.
- Also closes #78 because it caught my attention.
- Modified cursor highlighting graphics feature to never set the selection because that is not its job. Fixed the scanner indexing function to set the selection, which is what was supposed to happen in those cases.
- Entity part reading now prefers the already selected entity but when this is missing it defaults to the first primary entity.