### PR TITLE
Added travel menu search + fixed lingering graphics bug

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -2465,9 +2465,10 @@ function on_tick(event)
          elseif game.get_player(pindex).ticks_to_respawn ~= nil then
             printout(math.floor(game.get_player(pindex).ticks_to_respawn / 60) .. " seconds until respawn", pindex)
          end
-
          --Report the KK state, if any.
          fa_kk.status_read(pindex, false)
+         --Clear unwanted GUI remnants
+         fa_graphics.clear_player_GUI_remnants(pindex)
       end
    end
 end

--- a/control.lua
+++ b/control.lua
@@ -6822,7 +6822,7 @@ script.on_event(defines.events.on_gui_confirmed, function(event)
       --Destroy text fields
       if p.gui.screen["circuit-condition-constant"] ~= nil then p.gui.screen["circuit-condition-constant"].destroy() end
       if p.opened ~= nil then p.opened = nil end
-   elseif players[pindex].menu == "travel" then
+   elseif players[pindex].menu == "travel" and players[pindex].entering_search_term ~= true then
       --Edit a travel point
       local result = event.element.text
       if result == nil or result == "" then result = "blank" end

--- a/scripts/graphics.lua
+++ b/scripts/graphics.lua
@@ -540,10 +540,12 @@ end
 function mod.update_custom_GUI_sprite(sprite, scale_in, pindex, sprite_2)
    local player = players[pindex]
    local p = game.get_player(pindex)
-   local scale = scale_in
 
-   if sprite == nil and player.custom_GUI_frame ~= nil and player.custom_GUI_frame.valid then
-      player.custom_GUI_frame.visible = false
+   if sprite == nil then
+      if player.custom_GUI_frame ~= nil and player.custom_GUI_frame.valid then
+         player.custom_GUI_frame.visible = false
+      end
+      return
    else
       local f = player.custom_GUI_frame
       local s1 = player.custom_GUI_sprite
@@ -595,6 +597,15 @@ function mod.update_custom_GUI_sprite(sprite, scale_in, pindex, sprite_2)
       f.visible = true
       player.custom_GUI_frame = f
       f.bring_to_front()
+   end
+end
+
+function mod.clear_player_GUI_remnants(pindex)
+   local p = game.get_player(pindex)
+   if players[pindex].in_menu == false and players[pindex].menu == "none" and p.opened == nil then
+      if p and p.gui and p.gui.screen then
+         p.gui.screen.clear()
+      end
    end
 end
 

--- a/scripts/graphics.lua
+++ b/scripts/graphics.lua
@@ -603,9 +603,7 @@ end
 function mod.clear_player_GUI_remnants(pindex)
    local p = game.get_player(pindex)
    if players[pindex].in_menu == false and players[pindex].menu == "none" and p.opened == nil then
-      if p and p.gui and p.gui.screen then
-         p.gui.screen.clear()
-      end
+      if p and p.gui and p.gui.screen then p.gui.screen.clear() end
    end
 end
 

--- a/scripts/graphics.lua
+++ b/scripts/graphics.lua
@@ -615,6 +615,7 @@ function mod.update_overhead_sprite(sprite, scale_in, radius_in, pindex)
          surface = p.surface,
          target = { x = p.position.x, y = p.position.y - 3 - radius },
          filled = true,
+         time_to_live = 60,
       })
       rendering.set_visible(player.overhead_circle, true)
       player.overhead_sprite = rendering.draw_sprite({
@@ -624,6 +625,7 @@ function mod.update_overhead_sprite(sprite, scale_in, radius_in, pindex)
          surface = p.surface,
          target = { x = p.position.x, y = p.position.y - 3 - radius },
          orientation = dirs.north,
+         time_to_live = 60,
       })
       rendering.set_visible(player.overhead_sprite, true)
    end

--- a/scripts/menu-search.lua
+++ b/scripts/menu-search.lua
@@ -5,6 +5,7 @@ local fa_crafting = require("scripts.crafting")
 local localising = require("scripts.localising")
 local fa_sectors = require("scripts.building-vehicle-sectors")
 local fa_circuits = require("scripts.circuit-networks")
+local fa_travel = require("scripts/travel-tools")
 
 local mod = {}
 
@@ -191,6 +192,53 @@ local function prototypes_find_index_of_next_name_match(array, index, str, pinde
    return -1
 end
 
+local function travel_find_index_of_next_name_match(index, str, pindex)
+   local repeat_i = -1
+   local list_size = #players[pindex].travel
+   if index < 1 then index = 1 end
+   --Iterate until the end of the list for a match
+   for i = index, list_size, 1 do
+      local locus = players[pindex].travel[players[pindex].travel.index.y]
+      if locus and locus.name then
+         local name = string.lower(locus.name)
+         local result = string.find(name, str)
+         if result ~= nil then
+            if name ~= players[pindex].menu_search_last_name then
+               players[pindex].menu_search_last_name = name
+               game.get_player(pindex).play_sound({ path = "Inventory-Move" }) --sound for finding the next
+               return i
+            else
+               repeat_i = i
+            end
+         end
+         --game.print(i .. " : " .. name .. " vs. " .. str,{volume_modifier=0})
+      end
+   end
+   --End of inventory reached, circle back
+   game.get_player(pindex).play_sound({ path = "inventory-wrap-around" }) --sound for having cicled around
+   for i = 1, index, 1 do
+      local locus = players[pindex].travel[players[pindex].travel.index.y]
+      if locus and locus.name then
+         local name = string.lower(locus.name)
+         local result = string.find(name, str)
+         if result ~= nil then
+            if name ~= players[pindex].menu_search_last_name then
+               players[pindex].menu_search_last_name = name
+               game.get_player(pindex).play_sound({ path = "Inventory-Move" }) --sound for finding the next
+               return i
+            else
+               repeat_i = i
+            end
+         end
+         --game.print(i .. " : " .. name .. " vs. " .. str,{volume_modifier=0})
+      end
+   end
+   --Check if any repeats found
+   if repeat_i > 0 then return repeat_i end
+   --No matches found at all
+   return -1
+end
+
 --Allows searching a menu that has support written for this
 function mod.open_search_box(pindex)
    --Only allow "inventory" and "building" menus for now
@@ -206,6 +254,7 @@ function mod.open_search_box(pindex)
       and players[pindex].menu ~= "technology"
       and players[pindex].menu ~= "signal_selector"
       and players[pindex].menu ~= "player_trash"
+      and players[pindex].menu ~= "travel"
    then
       printout(players[pindex].menu .. " menu does not support searching.", pindex)
       return
@@ -246,6 +295,7 @@ function mod.fetch_next(pindex, str, start_phrase_in)
       and players[pindex].menu ~= "technology"
       and players[pindex].menu ~= "signal_selector"
       and players[pindex].menu ~= "player_trash"
+      and players[pindex].menu ~= "travel"
    then
       printout(players[pindex].menu .. " menu does not support searching.", pindex)
       return
@@ -371,6 +421,8 @@ function mod.fetch_next(pindex, str, start_phrase_in)
          players[pindex].signal_selector.signal_index = 0
       end
       --game.print("tries: " .. tries,{volume_modifier=0})--
+   elseif players[pindex].menu == "travel" then
+      new_index = travel_find_index_of_next_name_match(search_index, str, pindex)
    else
       printout("This menu or building sector does not support searching.", pindex)
       return
@@ -434,6 +486,10 @@ function mod.fetch_next(pindex, str, start_phrase_in)
       players[pindex].menu_search_index = new_index
       players[pindex].signal_selector.signal_index = new_index
       fa_circuits.read_selected_signal_slot(pindex, start_phrase)
+   elseif players[pindex].menu == "travel" then
+      players[pindex].menu_search_index = new_index
+      players[pindex].travel.index.y = new_index
+      fa_travel.read_fast_travel_slot(pindex)
    else
       printout("Search error", pindex)
       return

--- a/scripts/menu-search.lua
+++ b/scripts/menu-search.lua
@@ -193,10 +193,10 @@ end
 local function travel_find_index_of_next_name_match(index, str, pindex)
    local repeat_i = -1
    local list_size = #players[pindex].travel
-   if index < 1 then index = 1 end
+   if index == nil or index < 1 then index = 1 end
    --Iterate until the end of the list for a match
    for i = index, list_size, 1 do
-      local locus = players[pindex].travel[players[pindex].travel.index.y]
+      local locus = players[pindex].travel[i]
       if locus and locus.name then
          local name = string.lower(locus.name)
          local result = string.find(name, str)
@@ -209,13 +209,13 @@ local function travel_find_index_of_next_name_match(index, str, pindex)
                repeat_i = i
             end
          end
-         --game.print(i .. " : " .. name .. " vs. " .. str,{volume_modifier=0})
+         --game.print(i .. " : " .. name .. " vs. " .. str, { volume_modifier = 0 })
       end
    end
    --End of inventory reached, circle back
    game.get_player(pindex).play_sound({ path = "inventory-wrap-around" }) --sound for having cicled around
    for i = 1, index, 1 do
-      local locus = players[pindex].travel[players[pindex].travel.index.y]
+      local locus = players[pindex].travel[i]
       if locus and locus.name then
          local name = string.lower(locus.name)
          local result = string.find(name, str)
@@ -228,7 +228,7 @@ local function travel_find_index_of_next_name_match(index, str, pindex)
                repeat_i = i
             end
          end
-         --game.print(i .. " : " .. name .. " vs. " .. str,{volume_modifier=0})
+         --game.print(i .. " : " .. name .. " vs. " .. str, { volume_modifier = 0 })
       end
    end
    --Check if any repeats found

--- a/scripts/menu-search.lua
+++ b/scripts/menu-search.lua
@@ -1,6 +1,4 @@
 --Here: Menu search and directly related functions
-local util = require("util")
-local fa_utils = require("scripts.fa-utils")
 local fa_crafting = require("scripts.crafting")
 local localising = require("scripts.localising")
 local fa_sectors = require("scripts.building-vehicle-sectors")


### PR DESCRIPTION
Travel menu search works like the other menu search features.

The graphics bug was that after loading a game with a menu left open, unreferenced renders would be stuck in the world and on the player GUI. The solution was to make the renders expire and the graphics be periodically cleaned. This makes it far less needed to press "CONTROL + ALT + R".