### PR TITLE
add gun inventory support

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -5754,7 +5754,6 @@ function do_multi_stack_transfer(ratio, pindex)
       local offset = 1
       if players[pindex].building.recipe_list ~= nil then offset = offset + 1 end
       if players[pindex].building.sector_name == "player inventory from building" then
-         game.get_player(pindex).print("(inventory transfer issue?)", { volume_modifier = 0 })
          --This is the section where we move from the player to the building.
          local item_name = ""
          local stack = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
@@ -5803,7 +5802,6 @@ end
 * item name / empty string to indicate transfering everything
 * ratio (between 0 and 1), the ratio of the total count to transder for each item.
 * Has no checks or printouts!
-* persistent bug ***: only 1 inv transfer from player inv to chest can work, after that for some reason it always both inserts and takes back
 ]]
 function transfer_inventory(args)
    args.name = args.name or ""
@@ -5819,7 +5817,7 @@ function transfer_inventory(args)
       transfer_list = args.from.get_contents()
    end
    local full = false
-   local res = {}
+   local results = {}
    for name, amount in pairs(transfer_list) do
       if name ~= "blueprint" and name ~= "blueprint-book" then
          amount = math.ceil(amount * args.ratio)
@@ -5830,13 +5828,13 @@ function transfer_inventory(args)
             full = true
          end
          if amount > 0 then
-            res[name] = amount
+            results[name] = amount
             args.from.remove({ name = name, count = amount })
          end
       end
    end
    --game.print("run 1x: " .. args.name)--**
-   return res, full
+   return results, full
 end
 
 script.on_event("crafting-5", function(event)

--- a/control.lua
+++ b/control.lua
@@ -998,6 +998,12 @@ function read_coords(pindex, start_phrase)
          y = y - 1
       end
       printout(result .. " slot " .. x .. ", on row " .. y, pindex)
+   elseif players[pindex].menu == "guns" then
+      if players[pindex].guns_menu.ammo_selected then
+         printout("Ammo slot " .. players[pindex].guns_menu.index, pindex)
+      else
+         printout("Gun slot " .. players[pindex].guns_menu.index, pindex)
+      end
    elseif
       (players[pindex].menu == "building" or players[pindex].menu == "vehicle")
       and players[pindex].building.recipe_selection == false
@@ -6010,8 +6016,14 @@ script.on_event("item-info", function(event)
          if str == nil or str == "" then str = "No description for this entity" end
          printout(str, pindex)
       elseif hand and hand.valid_for_read then
-         local str = hand.prototype.localised_description
-         if str == nil or str == "" then str = "No description for the item in hand" end
+         local str = ""
+         if hand.prototype.place_result ~= nil then
+            str = hand.prototype.place_result.localised_description
+         else
+            str = hand.prototype.localised_description
+         end
+         if str == nil or str == "" then str = "No description" end
+         printout(str, pindex)
          local result = { "" }
          table.insert(result, "In hand: ")
          table.insert(result, str)
@@ -6039,6 +6051,15 @@ script.on_event("item-info", function(event)
             else
                str = stack.prototype.localised_description
             end
+            if str == nil or str == "" then str = "No description" end
+            printout(str, pindex)
+         else
+            printout("No description", pindex)
+         end
+      elseif players[pindex].menu == "guns" then
+         local stack = fa_equipment.guns_menu_get_selected_slot(pindex)
+         if stack and stack.valid_for_read then
+            str = stack.prototype.localised_description
             if str == nil or str == "" then str = "No description" end
             printout(str, pindex)
          else

--- a/control.lua
+++ b/control.lua
@@ -4919,6 +4919,8 @@ script.on_event("click-menu", function(event)
             players[pindex].signal_selector.ent,
             players[pindex].signal_selector.editing_first_slot
          )
+      elseif players[pindex].menu == "guns" then
+         fa_equipment.guns_menu_click_slot(pindex)
       end
    end
 end)
@@ -6028,8 +6030,7 @@ script.on_event("item-info", function(event)
       then
          local stack = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
          if players[pindex].menu == "player_trash" then
-            stack =
-               p.get_inventory(defines.inventory.character_trash)[players[pindex].inventory.index]
+            stack = p.get_inventory(defines.inventory.character_trash)[players[pindex].inventory.index]
          end
          if stack and stack.valid_for_read and stack.valid == true then
             local str = ""

--- a/control.lua
+++ b/control.lua
@@ -1352,6 +1352,11 @@ function initialize(player)
          edit_import = false,
       }
 
+   faplayer.guns_menu = faplayer.guns_menu or {
+      index = 1,
+      ammo_selected = false,
+   }
+
    if table_size(faplayer.mapped) == 0 then player.force.rechart() end
 
    faplayer.localisations = faplayer.localisations or {}
@@ -1725,6 +1730,8 @@ function menu_cursor_up(pindex)
    elseif players[pindex].menu == "signal_selector" then
       fa_circuits.signal_selector_group_up(pindex)
       fa_circuits.read_selected_signal_group(pindex, "")
+   elseif players[pindex].menu == "guns" then
+      fa_equipment.guns_menu_up_or_down(pindex)
    end
 end
 
@@ -1989,6 +1996,8 @@ function menu_cursor_down(pindex)
    elseif players[pindex].menu == "signal_selector" then
       fa_circuits.signal_selector_group_down(pindex)
       fa_circuits.read_selected_signal_group(pindex, "")
+   elseif players[pindex].menu == "guns" then
+      fa_equipment.guns_menu_up_or_down(pindex)
    end
 end
 
@@ -2140,6 +2149,8 @@ function menu_cursor_left(pindex)
    elseif players[pindex].menu == "signal_selector" then
       fa_circuits.signal_selector_signal_prev(pindex)
       fa_circuits.read_selected_signal_slot(pindex, "")
+   elseif players[pindex].menu == "guns" then
+      fa_equipment.guns_menu_left(pindex)
    end
 end
 
@@ -2308,6 +2319,8 @@ function menu_cursor_right(pindex)
    elseif players[pindex].menu == "signal_selector" then
       fa_circuits.signal_selector_signal_next(pindex)
       fa_circuits.read_selected_signal_slot(pindex, "")
+   elseif players[pindex].menu == "guns" then
+      fa_equipment.guns_menu_right(pindex)
    end
 end
 
@@ -5946,10 +5959,7 @@ script.on_event("inventory-read-weapons-data", function(event)
    if not players[pindex].in_menu then
       return
    elseif players[pindex].menu == "inventory" then
-      --Read Weapon data
-      local result = fa_equipment.read_weapons_and_ammo(pindex)
-      --game.get_player(pindex).print(result)--
-      printout(result, pindex)
+      fa_equipment.guns_menu_open(pindex)
    end
 end)
 

--- a/control.lua
+++ b/control.lua
@@ -5988,7 +5988,9 @@ end)
 script.on_event("item-info", function(event)
    pindex = event.player_index
    if not check_for_player(pindex) then return end
-   if game.get_player(pindex).driving and players[pindex].menu ~= "train_menu" then
+   local p = game.get_player(pindex)
+   local hand = p.cursor_stack
+   if p.driving and players[pindex].menu ~= "train_menu" then
       printout(fa_driving.vehicle_info(pindex), pindex)
       return
    end
@@ -6000,11 +6002,18 @@ script.on_event("item-info", function(event)
       offset = 1
    end
    if not players[pindex].in_menu then
-      local ent = game.get_player(pindex).selected
+      local ent = p.selected
       if ent and ent.valid then
          local str = ent.localised_description
          if str == nil or str == "" then str = "No description for this entity" end
          printout(str, pindex)
+      elseif hand and hand.valid_for_read then
+         local str = hand.prototype.localised_description
+         if str == nil or str == "" then str = "No description for the item in hand" end
+         local result = { "" }
+         table.insert(result, "In hand: ")
+         table.insert(result, str)
+         printout(result, pindex)
       else
          printout("Nothing selected, use this key to describe an entity or item that you select.", pindex)
       end
@@ -6020,7 +6029,7 @@ script.on_event("item-info", function(event)
          local stack = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
          if players[pindex].menu == "player_trash" then
             stack =
-               game.get_player(pindex).get_inventory(defines.inventory.character_trash)[players[pindex].inventory.index]
+               p.get_inventory(defines.inventory.character_trash)[players[pindex].inventory.index]
          end
          if stack and stack.valid_for_read and stack.valid == true then
             local str = ""

--- a/scripts/equipment.lua
+++ b/scripts/equipment.lua
@@ -484,15 +484,19 @@ function mod.guns_menu_click_slot(pindex)
    local gun_stack = p.get_inventory(defines.inventory.character_guns)[menu.index]
    local ammo_stack = p.get_inventory(defines.inventory.character_ammo)[menu.index]
    local selected_stack = nil
-   if menu.ammo_selected then selected_stack = ammo_stack else selected_stack = gun_stack end
+   if menu.ammo_selected then
+      selected_stack = ammo_stack
+   else
+      selected_stack = gun_stack
+   end
    if hand and hand.valid_for_read then
       --FUll hand operations
       if selected_stack == nil then
          --Empty slot
-         if menu.ammo_selected and not hand.is_ammo then
-            printout("Slot reserved for ammo types only", pindex)
+         if menu.ammo_selected and hand.type ~= "ammo" then
+            printout("Error: Slot reserved for ammo types only", pindex)
          elseif not menu.ammo_selected and hand.type ~= "gun" then
-            printout("Slot reserved for gun types only", pindex)
+            printout("Error: Slot reserved for gun types only", pindex)
          else
             hand.swap_stack(selected_stack)
             --If the swap is successful then the following print statement is overwritten.
@@ -500,17 +504,17 @@ function mod.guns_menu_click_slot(pindex)
          end
       else
          --Full slot
-         if menu.ammo_selected and not hand.is_ammo then
-            printout("Slot reserved for ammo types only", pindex)
+         if menu.ammo_selected and hand.type ~= "ammo" then
+            printout("Error: Slot reserved for ammo types only", pindex)
          elseif not menu.ammo_selected and hand.type ~= "gun" then
-            printout("Slot reserved for gun types only", pindex)
+            printout("Error: Slot reserved for gun types only", pindex)
          else
             hand.swap_stack(selected_stack)
             --If the swap is successful then the following print statement is overwritten.
             printout("Error: Incompatible gun and ammo types", pindex)
          end
       end
-   elseif hand == nil then
+   else
       --Empty hand
       if selected_stack and selected_stack.valid_for_read then
          --Pick up the thing

--- a/scripts/equipment.lua
+++ b/scripts/equipment.lua
@@ -396,4 +396,67 @@ function mod.remove_equipment_and_armor(pindex)
    return result
 end
 
+function mod.guns_menu_open(pindex)
+   local p = game.get_player(pindex)
+   players[pindex].menu = "guns"
+   players[pindex].guns_menu.ammo_selected = false
+   players[pindex].guns_menu.index = 1
+   mod.guns_menu_read_slot("Guns and ammo, ", pindex)
+end
+
+function mod.guns_menu_left(pindex)
+
+end
+
+function mod.guns_menu_right(pindex)
+
+end
+
+function mod.guns_menu_up_or_down(pindex)
+
+end
+
+function mod.guns_menu_read_slot(start_phrase_in, pindex)
+   local start_phrase = start_phrase_in or ""
+   local menu = players[pindex].guns_menu
+   local p = game.get_player(pindex)
+   local result = { "" }
+   local gun_stack = p.get_inventory(defines.inventory.character_guns)[menu.index]
+   local ammo_stack = p.get_inventory(defines.inventory.character_ammo)[menu.index]
+   if menu.ammo_selected then
+      if ammo_stack and ammo_stack.valid_for_read then
+         --Read the ammo
+         table.insert(result, ammo_stack.name .. " " .. "times" ..  " " .. ammo_stack.count)
+      else
+         table.insert(result, "empty ammo stack")
+      end
+      table.insert(result, "for")
+      if gun_stack and gun_stack.valid_for_read then
+         table.insert(result, gun_stack.name)
+      else
+         table.insert(result, "empty gun slot")
+      end
+   else
+      if gun_stack and gun_stack.valid_for_read then
+         table.insert(result, gun_stack.name)
+         if stack.count > 1 then
+            table.insert(result, "times" .. " " .. stack.count)
+         end
+      else
+         table.insert(result, "empty gun slot")
+      end
+      table.insert(result, "with")
+      if ammo_stack and ammo_stack.valid_for_read then
+         --Read the ammo
+         table.insert(result, ammo_stack.name .. " " .. "times" ..  " " .. ammo_stack.count)
+      else
+         table.insert(result, "no ammo")
+      end
+   end
+end
+
+function mod.guns_menu_click_slot(pindex)
+
+end
+
 return mod

--- a/scripts/equipment.lua
+++ b/scripts/equipment.lua
@@ -437,6 +437,18 @@ function mod.guns_menu_up_or_down(pindex)
    mod.guns_menu_read_slot(pindex)
 end
 
+function mod.guns_menu_get_selected_slot(pindex)
+   local menu = players[pindex].guns_menu
+   local p = game.get_player(pindex)
+   local gun_stack = p.get_inventory(defines.inventory.character_guns)[menu.index]
+   local ammo_stack = p.get_inventory(defines.inventory.character_ammo)[menu.index]
+   if menu.ammo_selected then
+      return ammo_stack
+   else
+      return gun_stack
+   end
+end
+
 function mod.guns_menu_read_slot(pindex, start_phrase_in)
    local start_phrase = start_phrase_in or ""
    local menu = players[pindex].guns_menu

--- a/scripts/equipment.lua
+++ b/scripts/equipment.lua
@@ -450,7 +450,7 @@ function mod.guns_menu_read_slot(pindex, start_phrase_in)
       if ammo_stack and ammo_stack.valid_for_read then
          table.insert(result, ammo_stack.name .. " " .. "times" .. " " .. ammo_stack.count)
       else
-         table.insert(result, "empty ammo stack")
+         table.insert(result, "empty ammo slot")
       end
       table.insert(result, " for ")
       if gun_stack and gun_stack.valid_for_read then
@@ -479,6 +479,46 @@ end
 
 function mod.guns_menu_click_slot(pindex)
    local p = game.get_player(pindex)
+   local hand = p.cursor_stack
+   local menu = players[pindex].guns_menu
+   local gun_stack = p.get_inventory(defines.inventory.character_guns)[menu.index]
+   local ammo_stack = p.get_inventory(defines.inventory.character_ammo)[menu.index]
+   local selected_stack = nil
+   if menu.ammo_selected then selected_stack = ammo_stack else selected_stack = gun_stack end
+   if hand and hand.valid_for_read then
+      --FUll hand operations
+      if selected_stack == nil then
+         --Empty slot
+         if menu.ammo_selected and not hand.is_ammo then
+            printout("Slot reserved for ammo types only", pindex)
+         elseif not menu.ammo_selected and hand.type ~= "gun" then
+            printout("Slot reserved for gun types only", pindex)
+         else
+            hand.swap_stack(selected_stack)
+            --If the swap is successful then the following print statement is overwritten.
+            printout("Error: Incompatible gun and ammo types", pindex)
+         end
+      else
+         --Full slot
+         if menu.ammo_selected and not hand.is_ammo then
+            printout("Slot reserved for ammo types only", pindex)
+         elseif not menu.ammo_selected and hand.type ~= "gun" then
+            printout("Slot reserved for gun types only", pindex)
+         else
+            hand.swap_stack(selected_stack)
+            --If the swap is successful then the following print statement is overwritten.
+            printout("Error: Incompatible gun and ammo types", pindex)
+         end
+      end
+   elseif hand == nil then
+      --Empty hand
+      if selected_stack and selected_stack.valid_for_read then
+         --Pick up the thing
+         hand.swap_stack(selected_stack)
+      else
+         printout("No action", pindex)
+      end
+   end
 end
 
 return mod

--- a/scripts/equipment.lua
+++ b/scripts/equipment.lua
@@ -142,10 +142,15 @@ function mod.reload_weapons(pindex)
    end
    --Apply an inventory transfer to the ammo inventory.
    local res, full = transfer_inventory({ from = main_inv, to = ammo_inv })
-   --**laterdo fail conditions messages, and maybe add reload sound?
+   local moved_key_count = 0
+   for key, val in pairs(res) do
+      moved_key_count = moved_key_count + 1
+   end
    --Check fullness
    if ammo_inv.is_full() then
       result = "Fully reloaded all three weapons"
+   elseif moved_key_count == 0 then
+      result = "Error: No relevant ammo found for reloading"
    else
       result = "Reloaded weapons with any available ammunition, "
    end

--- a/scripts/equipment.lua
+++ b/scripts/equipment.lua
@@ -401,62 +401,84 @@ function mod.guns_menu_open(pindex)
    players[pindex].menu = "guns"
    players[pindex].guns_menu.ammo_selected = false
    players[pindex].guns_menu.index = 1
-   mod.guns_menu_read_slot("Guns and ammo, ", pindex)
+   mod.guns_menu_read_slot(pindex, "Guns and ammo, ")
 end
 
 function mod.guns_menu_left(pindex)
-
+   local index = players[pindex].guns_menu.index
+   index = index - 1
+   if index == 0 then
+      index = 3
+      game.get_player(pindex).play_sound({ path = "inventory-wrap-around" })
+   else
+      game.get_player(pindex).play_sound({ path = "Inventory-Move" })
+   end
+   players[pindex].guns_menu.index = index
+   game.get_player(pindex).play_sound({ path = "Inventory-Move" })
+   mod.guns_menu_read_slot(pindex)
 end
 
 function mod.guns_menu_right(pindex)
-
+   local index = players[pindex].guns_menu.index
+   index = index + 1
+   if index == 4 then
+      index = 1
+      game.get_player(pindex).play_sound({ path = "inventory-wrap-around" })
+   else
+      game.get_player(pindex).play_sound({ path = "Inventory-Move" })
+   end
+   players[pindex].guns_menu.index = index
+   mod.guns_menu_read_slot(pindex)
 end
 
 function mod.guns_menu_up_or_down(pindex)
-
+   players[pindex].guns_menu.ammo_selected = not players[pindex].guns_menu.ammo_selected
+   game.get_player(pindex).play_sound({ path = "Inventory-Move" })
+   mod.guns_menu_read_slot(pindex)
 end
 
-function mod.guns_menu_read_slot(start_phrase_in, pindex)
+function mod.guns_menu_read_slot(pindex, start_phrase_in)
    local start_phrase = start_phrase_in or ""
    local menu = players[pindex].guns_menu
    local p = game.get_player(pindex)
    local result = { "" }
+   table.insert(result, start_phrase)
    local gun_stack = p.get_inventory(defines.inventory.character_guns)[menu.index]
    local ammo_stack = p.get_inventory(defines.inventory.character_ammo)[menu.index]
    if menu.ammo_selected then
+      --Read the ammo slot
       if ammo_stack and ammo_stack.valid_for_read then
-         --Read the ammo
-         table.insert(result, ammo_stack.name .. " " .. "times" ..  " " .. ammo_stack.count)
+         table.insert(result, ammo_stack.name .. " " .. "times" .. " " .. ammo_stack.count)
       else
          table.insert(result, "empty ammo stack")
       end
-      table.insert(result, "for")
+      table.insert(result, " for ")
       if gun_stack and gun_stack.valid_for_read then
          table.insert(result, gun_stack.name)
       else
          table.insert(result, "empty gun slot")
       end
    else
+      --Read the gun slot
       if gun_stack and gun_stack.valid_for_read then
          table.insert(result, gun_stack.name)
-         if stack.count > 1 then
-            table.insert(result, "times" .. " " .. stack.count)
-         end
+         if gun_stack.count > 1 then table.insert(result, "times" .. " " .. gun_stack.count) end
       else
          table.insert(result, "empty gun slot")
       end
-      table.insert(result, "with")
+      table.insert(result, " using ")
       if ammo_stack and ammo_stack.valid_for_read then
          --Read the ammo
-         table.insert(result, ammo_stack.name .. " " .. "times" ..  " " .. ammo_stack.count)
+         table.insert(result, ammo_stack.name .. " " .. "times" .. " " .. ammo_stack.count)
       else
          table.insert(result, "no ammo")
       end
    end
+   printout(result, pindex)
 end
 
 function mod.guns_menu_click_slot(pindex)
-
+   local p = game.get_player(pindex)
 end
 
 return mod

--- a/scripts/fa-info.lua
+++ b/scripts/fa-info.lua
@@ -6,6 +6,7 @@ local util = require("util")
 local fa_utils = require("scripts.fa-utils")
 local fa_localising = require("scripts.localising")
 local fa_electrical = require("scripts.electrical")
+local fa_equipment = require("scripts.equipment")
 local fa_graphics = require("scripts.graphics")
 local fa_building_tools = require("scripts.building-tools")
 local fa_rails = require("scripts.rails")
@@ -1159,9 +1160,12 @@ function mod.selected_item_production_stats_info(pindex)
    item_stack = p.cursor_stack
    if item_stack and item_stack.valid_for_read then prototype = item_stack.prototype end
 
-   --Otherwise try to get it from the inventory.
+   --Otherwise try to get it from the inventory slots
    if prototype == nil and players[pindex].menu == "inventory" then
       item_stack = players[pindex].inventory.lua_inventory[players[pindex].inventory.index]
+      if item_stack and item_stack.valid_for_read then prototype = item_stack.prototype end
+   elseif prototype == nil and players[pindex].menu == "guns" then
+      item_stack = fa_equipment.guns_menu_get_selected_slot(pindex)
       if item_stack and item_stack.valid_for_read then prototype = item_stack.prototype end
    end
 

--- a/scripts/graphics.lua
+++ b/scripts/graphics.lua
@@ -67,6 +67,9 @@ function mod.update_menu_visuals()
          elseif player.menu == "player_trash" then
             mod.update_overhead_sprite("utility.trash_white", 2, 1.25, pindex)
             mod.update_custom_GUI_sprite("utility.trash_white", 3, pindex)
+         elseif player.menu == "guns" then
+            mod.update_overhead_sprite("item.pistol", 2, 1.25, pindex)
+            mod.update_custom_GUI_sprite("item.pistol", 1, pindex)
          elseif player.menu == "travel" then
             mod.update_overhead_sprite("utility.downloading_white", 4, 1.25, pindex)
             mod.update_custom_GUI_sprite("utility.downloading_white", 3, pindex)


### PR DESCRIPTION
### Guns and ammo menu additions
- Adding a guns and ammo inventory that you open from the character inventory menu by pressing `R`. This replaces the old guns and ammo summary.
- Slots can be navigated with WASD and interacted using the hand like regular inventory slots.
- There is also added support for:
  * item info with Y 
  * slot info with K
  * item logistic info with L
  * item production info with U
- Menu search will not be added because there is a grand total of 6 slots anyway.
- Closes #197.
- Closes #95.

### Other additions
- Added item description reading for an item in hand when no menu is open and no entity is selected.
- Simplified code and improved error reporting for logistic request related actions