### PR TITLE
fix: resolve viewing inserter with filters set crashes game

### DIFF
--- a/scripts/fa-info.lua
+++ b/scripts/fa-info.lua
@@ -1132,6 +1132,8 @@ local function ent_info_filters(ctx)
          ctx.message:list_item()
          if first then ctx.message:fragment("Filters for") end
          first = false
+         --We seem to be getting string names in 2.0; lookup the actual prototype to use
+         if type(proto) == "string" then proto = prototypes.item[proto] end
          ctx.message:fragment(Localising.get_localised_name_with_fallback(proto))
       end
    end


### PR DESCRIPTION
Factorio 2.0 may return filter names as strings. Viewing an inserter with filters set would crash due to an assertion when localising. Fixed by checking for string filters and looking up the prototype before localisation.