### PR TITLE
fix: update direction localisation for 16 directions and correct typo

### DIFF
--- a/locale/en/factorio-access.cfg
+++ b/locale/en/factorio-access.cfg
@@ -2,7 +2,7 @@
 [fa]
 #direction
 #eg North
-direction=__plural_for_parameter__1___{0=North|1=NorthEast|2=East|3=SouthEast|4=South|5=SouthWest|6=West|7=NorthWest|rest=}__
+direction=__plural_for_parameter__1__{0=North|1=NorthNorthEast|2=NorthEast|3=EastNorthEast|4=East|5=EastSouthEast|6=SouthEast|7=SouthSouthEast|8=South|9=SouthSouthWest|10=SouthWest|11=WestSouthWest|12=West|13=WestNorthWest|14=NorthWest|15=NorthNorthWest|rest=}__
 
 #entity direction
 #eg facing North


### PR DESCRIPTION
English direction localisation now covers all 16 directions. Also fixed an extra underscore in the parameter that was breaking localisation. Issue was found while nudging buildings but likely affected other features.