### PR TITLE
Some fixes

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -7420,7 +7420,7 @@ EventManager.on_event("fa-c-rightbracket", function(event)
    * Control click an item in an inventory to try smart transfer HALF of it. 
    * Control click an empty slot to try to smart transfer HALF of all items from that inventory.
    ]]
-   if router:is_ui_open() and router:is_ui_one_of({ UiRouter.UI_NA.BUILDING, UiRouter.UI_NAMES.VEHICLE }) then
+   if router:is_ui_open() and router:is_ui_one_of({ UiRouter.UI_NAMES.BUILDING, UiRouter.UI_NAMES.VEHICLE }) then
       ---From event transfer-half-of-all-stacks
       do_multi_stack_transfer(0.5, pindex)
    end

--- a/control.lua
+++ b/control.lua
@@ -2409,7 +2409,7 @@ function do_multi_stack_transfer(ratio, pindex)
          local listed_count = 0
          for name, amount in pairs(moved) do
             if listed_count <= 5 then
-               table.insert(item_list, Localising.localise_item({ item = name, count = amount }))
+               table.insert(item_list, Localising.localise_item({ name = name, count = amount }))
                table.insert(item_list, ", ")
             else
                other_items = other_items + amount
@@ -2417,10 +2417,10 @@ function do_multi_stack_transfer(ratio, pindex)
             listed_count = listed_count + 1
          end
          if other_items > 0 then
-            table.insert(item_list, Localising.localise_item({ item = Localising.ITEM_OTHER, count = other_items }))
+            table.insert(item_list, Localising.localise_item({ name = Localising.ITEM_OTHER, count = other_items }))
             table.insert(item_list, ", ")
          end
-         --trim traling comma off
+         -- trim trailing comma off
          item_list[#item_list] = nil
          table.insert(result, { "fa.grabbed-stuff", item_list })
       end
@@ -2453,7 +2453,7 @@ function do_multi_stack_transfer(ratio, pindex)
             local listed_count = 0
             for name, amount in pairs(moved) do
                if listed_count <= 5 then
-                  table.insert(item_list, Localising.localise_item({ item = name, count = amount }))
+                  table.insert(item_list, Localising.localise_item({ name = name, count = amount }))
                   table.insert(item_list, ", ")
                else
                   other_items = other_items + amount
@@ -2461,10 +2461,10 @@ function do_multi_stack_transfer(ratio, pindex)
                listed_count = listed_count + 1
             end
             if other_items > 0 then
-               table.insert(item_list, Localising.localise_item({ item = Localising.ITEM_OTHER, count = other_items }))
+               table.insert(item_list, Localising.localise_item({ name = Localising.ITEM_OTHER, count = other_items }))
                table.insert(item_list, ", ")
             end
-            --trim trailing comma off
+            -- trim trailing comma off
             item_list[#item_list] = nil
             table.insert(result, { "fa.placed-stuff", FaUtils.breakup_string(item_list) })
          end

--- a/control.lua
+++ b/control.lua
@@ -796,8 +796,8 @@ function initialize(player)
    faplayer.walk = faplayer.walk or 0
    faplayer.move_queue = faplayer.move_queue or {}
    faplayer.building_direction = faplayer.building_direction or dirs.north --top
-   faplayer.building_footprint = faplayer.building_footprint or nil
-   faplayer.building_dir_arrow = faplayer.building_dir_arrow or nil
+   faplayer.building_footprint = nil
+   faplayer.building_dir_arrow = nil
    faplayer.overhead_sprite = nil
    faplayer.overhead_circle = nil
    faplayer.custom_GUI_frame = nil

--- a/control.lua
+++ b/control.lua
@@ -796,8 +796,15 @@ function initialize(player)
    faplayer.walk = faplayer.walk or 0
    faplayer.move_queue = faplayer.move_queue or {}
    faplayer.building_direction = faplayer.building_direction or dirs.north --top
-   faplayer.building_footprint = nil
-   faplayer.building_dir_arrow = nil
+
+   if type(faplayer.building_footprint) == "number" then
+       faplayer.building_footprint = nil
+   end
+
+   if type(faplayer.building_dir_arrow) == "number" then
+       faplayer.building_dir_arrow = nil
+   end
+
    faplayer.overhead_sprite = nil
    faplayer.overhead_circle = nil
    faplayer.custom_GUI_frame = nil

--- a/control.lua
+++ b/control.lua
@@ -4792,24 +4792,37 @@ local function read_coords(pindex, start_phrase)
       --Read recipe ingredients / products (crafting menu)
       local recipe =
          players[pindex].crafting.lua_recipes[players[pindex].crafting.category][players[pindex].crafting.index]
-      result = result .. "Ingredients: "
+      local msg = MessageBuilder.new()
+      if result ~= "" then
+         msg:fragment(result)
+         msg:fragment(" ")
+      end
+      msg:fragment("Ingredients: ")
       for i, v in pairs(recipe.ingredients) do
          ---@type LuaItemPrototype | LuaFluidPrototype
          local proto = prototypes.item[v.name]
          if proto == nil then proto = prototypes.fluid[v.name] end
-         local localised_name = Localising.get_localised_name_with_fallback(proto)
-         result = result .. ", " .. localised_name .. " times " .. v.amount
+         local name = Localising.get_localised_name_with_fallback(proto)
+         msg:fragment(", ")
+         msg:fragment(name)
+         msg:fragment(" times ")
+         msg:fragment(tostring(v.amount))
       end
-      result = result .. ", Products: "
+      msg:fragment(", Products: ")
       for i, v in pairs(recipe.products) do
          ---@type LuaItemPrototype | LuaFluidPrototype
          local proto = prototypes.item[v.name]
          if proto == nil then proto = prototypes.fluid[v.name] end
-         local localised_name = Localising.get_localised_name_with_fallback(proto)
-         result = result .. ", " .. localised_name .. " times " .. v.amount
+         local name = Localising.get_localised_name_with_fallback(proto)
+         msg:fragment(", ")
+         msg:fragment(name)
+         msg:fragment(" times ")
+         msg:fragment(tostring(v.amount))
       end
-      result = result .. ", craft time " .. recipe.energy .. " seconds by default."
-      printout(result, pindex)
+      msg:fragment(", craft time ")
+      msg:fragment(tostring(recipe.energy))
+      msg:fragment(" seconds by default.")
+      printout(msg:build(), pindex)
    elseif router:is_ui_open(UiRouter.UI_NAMES.TECHNOLOGY) then
       Research.menu_describe_costs(pindex)
    end
@@ -4820,24 +4833,39 @@ local function read_coords(pindex, start_phrase)
       --Read recipe ingredients / products (building recipe selection)
       local recipe =
          players[pindex].building.recipe_list[players[pindex].building.category][players[pindex].building.index]
-      result = result .. "Ingredients: "
+      local msg = MessageBuilder.new()
+      if result ~= "" then
+         msg:fragment(result)
+         msg:fragment(" ")
+      end
+      msg:fragment("Ingredients: ")
       for i, v in pairs(recipe.ingredients) do
          ---@type LuaItemPrototype | LuaFluidPrototype
          local proto = prototypes.item[v.name]
          if proto == nil then proto = prototypes.fluid[v.name] end
-         local localised_name = Localising.get_localised_name_with_fallback(proto)
-         result = result .. ", " .. localised_name .. " x" .. v.amount .. " per cycle "
+         local name = Localising.get_localised_name_with_fallback(proto)
+         msg:fragment(", ")
+         msg:fragment(name)
+         msg:fragment(" x")
+         msg:fragment(tostring(v.amount))
+         msg:fragment(" per cycle ")
       end
-      result = result .. ", products: "
+      msg:fragment(", products: ")
       for i, v in pairs(recipe.products) do
          ---@type LuaItemPrototype | LuaFluidPrototype
          local proto = prototypes.item[v.name]
          if proto == nil then proto = prototypes.fluid[v.name] end
-         local localised_name = Localising.get_localised_name_with_fallback(proto)
-         result = result .. ", " .. localised_name .. " x" .. v.amount .. " per cycle "
+         local name = Localising.get_localised_name_with_fallback(proto)
+         msg:fragment(", ")
+         msg:fragment(name)
+         msg:fragment(" x")
+         msg:fragment(tostring(v.amount))
+         msg:fragment(" per cycle ")
       end
-      result = result .. ", craft time " .. recipe.energy .. " seconds at default speed."
-      printout(result, pindex)
+      msg:fragment(", craft time ")
+      msg:fragment(tostring(recipe.energy))
+      msg:fragment(" seconds at default speed.")
+      printout(msg:build(), pindex)
    end
 end
 

--- a/locale/en/factorio-access.cfg
+++ b/locale/en/factorio-access.cfg
@@ -65,7 +65,7 @@ failed-inventory-limit-ajust-no-limit=This inventory does not support limiting.
 #changing inventory limit on chest, __1__ will be __gui.all__ and __2__ will be 1000 when max is reached
 #eg 1 slot unlocked.
 #eg All slots unlocked.
-inventory-limit-status=__1__ __plural_for_parameter__2___{1=slot|rest=slots}__ unlocked.
+inventory-limit-status=__1__ __plural_for_parameter__2__{1=slot|rest=slots}__ unlocked.
 
 #nudging
 nudged-one-direction=Moved building 1 __1__.

--- a/scripts/building-vehicle-sectors.lua
+++ b/scripts/building-vehicle-sectors.lua
@@ -692,20 +692,24 @@ function mod.read_sector_slot(pindex, prefix_inventory_size_and_name, start_phra
             and players[pindex].building.ent.valid
             and players[pindex].building.ent.type == "roboport"
          then
-            table.insert(result, { "fa.bvs-reserved-for" })
-            table.insert(result, " ")
-            table.insert(result, "worker robots")
-            table.insert(result, " ")
+            local message = MessageBuilder.new()
+            if start_phrase ~= "" then message:fragment(start_phrase) end
+            message:list_item({ "fa.bvs-reserved-for" })
+            message:list_item("worker robots")
+            printout(message:build(), pindex)
+            return
          elseif
             players[pindex].building.ent ~= nil
             and players[pindex].building.ent.valid
-            and players[pindex].building.ent.type == "ammo-turret"
-            or players[pindex].building.ent.type == "artillery-turret"
+            and (players[pindex].building.ent.type == "ammo-turret"
+                 or players[pindex].building.ent.type == "artillery-turret")
          then
-            table.insert(result, { "fa.bvs-reserved-for" })
-            table.insert(result, " ")
-            table.insert(result, "ammo")
-            table.insert(result, " ")
+            local message = MessageBuilder.new()
+            if start_phrase ~= "" then message:fragment(start_phrase) end
+            message:list_item({ "fa.bvs-reserved-for" })
+            message:list_item("ammo")
+            printout(message:build(), pindex)
+            return
          end
          printout({ "", start_phrase, result }, pindex)
       end

--- a/scripts/building-vehicle-sectors.lua
+++ b/scripts/building-vehicle-sectors.lua
@@ -457,7 +457,7 @@ function mod.read_sector_slot(pindex, prefix_inventory_size_and_name, start_phra
          game.get_player(pindex).play_sound({ path = "inventory-wrap-around" })
       end
       local capacity = box.get_capacity(players[pindex].building.index)
-      local type = box.get_prototype(players[pindex].building.index).production_type
+      local fluid_type = box.get_prototype(players[pindex].building.index).production_type
       local fluid = box[players[pindex].building.index]
       local len = #box
       if prefix_inventory_size_and_name then
@@ -471,7 +471,7 @@ function mod.read_sector_slot(pindex, prefix_inventory_size_and_name, start_phra
          name = localising.get_localised_name_with_fallback(prototypes.fluid[fluid.name])
       end --laterdo use fluidbox.get_locked_fluid(i) if needed.
       --Read the fluid ingredients & products
-      --Note: We could have separated by input/output but right now the "type" is "input" for all fluids it seeems?
+      --Note: Could separate by input/output, but production_type (fluid_type) currently always "input"
       local recipe = players[pindex].building.recipe
       if recipe ~= nil then
          local index = players[pindex].building.index

--- a/scripts/building-vehicle-sectors.lua
+++ b/scripts/building-vehicle-sectors.lua
@@ -692,16 +692,22 @@ function mod.read_sector_slot(pindex, prefix_inventory_size_and_name, start_phra
             and players[pindex].building.ent.valid
             and players[pindex].building.ent.type == "roboport"
          then
-            result = result .. " reserved for worker robots "
+            table.insert(result, { "fa.bvs-reserved-for" })
+            table.insert(result, " ")
+            table.insert(result, "worker robots")
+            table.insert(result, " ")
          elseif
             players[pindex].building.ent ~= nil
-               and players[pindex].building.ent.valid
-               and players[pindex].building.ent.type == "ammo-turret"
+            and players[pindex].building.ent.valid
+            and players[pindex].building.ent.type == "ammo-turret"
             or players[pindex].building.ent.type == "artillery-turret"
          then
-            result = result .. " reserved for ammo "
+            table.insert(result, { "fa.bvs-reserved-for" })
+            table.insert(result, " ")
+            table.insert(result, "ammo")
+            table.insert(result, " ")
          end
-         printout(start_phrase .. result, pindex)
+         printout({ "", start_phrase, result }, pindex)
       end
    elseif prefix_inventory_size_and_name then
       printout("0 " .. building_sector.name, pindex)

--- a/scripts/crafting.lua
+++ b/scripts/crafting.lua
@@ -26,9 +26,14 @@ function mod.get_recipes(pindex, ent, load_all_categories)
 
    --Load only the unlocked recipes
    for recipe_name, recipe in pairs(all_machine_recipes) do
-      if force_recipes[recipe_name] ~= nil and force_recipes[recipe_name].enabled then
-         if unlocked_machine_recipes[recipe.group.name] == nil then unlocked_machine_recipes[recipe.group.name] = {} end
-         table.insert(unlocked_machine_recipes[recipe.group.name], force_recipes[recipe.name])
+      local force_recipe = force_recipes[recipe_name]
+      local proto = prototypes.recipe[recipe_name]
+      -- only include enabled, non-hidden recipes that actually produce items
+      if force_recipe and force_recipe.enabled and not force_recipe.hidden
+         and proto and next(proto.products) then
+         local grp = recipe.group.name
+         unlocked_machine_recipes[grp] = unlocked_machine_recipes[grp] or {}
+         table.insert(unlocked_machine_recipes[grp], force_recipe)
       end
    end
    local result = {}

--- a/scripts/localising.lua
+++ b/scripts/localising.lua
@@ -181,7 +181,7 @@ mod.ITEM_OTHER = {}
 Localise an item, or fluid, possibly with count and quality.
 
 This function can take two things.  An LuaItemStack, or a table with 3 keys:
-item, quality, and count.  In that table, item and quality may either be a
+name, quality, and count.  In that table, name and quality may either be a
 string or a LuaXXXPrototype.  It:
 
 - For the case of stacks, "transport belt X 50" or (for non-normal quality)
@@ -191,7 +191,7 @@ string or a LuaXXXPrototype.  It:
   it being announced.
 
 for the case of "and 5 other items" you may use mod.ITEM_OTHER in place of the
-item.
+name.
 ]]
 ---@param what LuaItemStack | fa.Localising.LocaliseItemOpts
 ---@param protos table<string, LuaItemPrototype|LuaFluidPrototype>

--- a/scripts/ui/belt-analyzer.lua
+++ b/scripts/ui/belt-analyzer.lua
@@ -69,8 +69,10 @@ local function label_local_cell(ctx, x, y)
 
    local contents = node:get_all_contents()
 
-   local bucket = contents[x][y]
-   assert(bucket)
+   local bucket = contents[x] and contents[x][y]
+   if not bucket then
+      return { "fa.ui-belt-analyzer-empty" }
+   end
 
    if not next(bucket.items) then return { "fa.ui-belt-analyzer-empty" } end
 


### PR DESCRIPTION
- Refactored sector slot (scripts/building-vehicle-sectors.lua) and recipe info (control.lua) output to avoid crashes
- Improved localization
  - Use "fa.bvs-reserved-for" in read_sector_slot function (scripts/building-vehicle-sectors.lua)
- Reset building_footprint and building_dir_arrow state on player initialization if they're numbers to fix a crash when loading 1.1 saves (control.lua)
- Avoid shadowing Lua type() in read_sector_slot (scripts/building-vehicle-sectors.lua)
- Fix interaction with underground belt exits (ui/belt-analyzer.lua)