### PR TITLE
Fix nil reference crashes in scanner and equipment systems

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -3835,6 +3835,14 @@ local function read_coords(pindex, start_phrase)
       end
       Speech.speak(pindex, { "fa.inventory-slot-position", result, tostring(x), tostring(y) })
    elseif router:is_ui_open(UiRouter.UI_NAMES.GUNS) then
+      -- Initialize guns_menu if it doesn't exist
+      if not storage.players[pindex].guns_menu then
+         storage.players[pindex].guns_menu = {
+            ammo_selected = false,
+            index = 1,
+         }
+      end
+
       if storage.players[pindex].guns_menu.ammo_selected then
          Speech.speak(pindex, { "fa.ammo-slot", tostring(storage.players[pindex].guns_menu.index) })
       else

--- a/scripts/equipment.lua
+++ b/scripts/equipment.lua
@@ -497,12 +497,29 @@ function mod.guns_menu_open(pindex)
 
    local p = game.get_player(pindex)
    router:open_ui(UiRouter.UI_NAMES.GUNS)
+
+   -- Initialize guns_menu if it doesn't exist
+   if not storage.players[pindex].guns_menu then
+      storage.players[pindex].guns_menu = {
+         ammo_selected = false,
+         index = 1,
+      }
+   end
+
    storage.players[pindex].guns_menu.ammo_selected = false
    storage.players[pindex].guns_menu.index = 1
    mod.guns_menu_read_slot(pindex, "Guns and ammo, ")
 end
 
 function mod.guns_menu_left(pindex)
+   -- Initialize guns_menu if it doesn't exist
+   if not storage.players[pindex].guns_menu then
+      storage.players[pindex].guns_menu = {
+         ammo_selected = false,
+         index = 1,
+      }
+   end
+
    local index = storage.players[pindex].guns_menu.index
    index = index - 1
    if index == 0 then
@@ -517,6 +534,14 @@ function mod.guns_menu_left(pindex)
 end
 
 function mod.guns_menu_right(pindex)
+   -- Initialize guns_menu if it doesn't exist
+   if not storage.players[pindex].guns_menu then
+      storage.players[pindex].guns_menu = {
+         ammo_selected = false,
+         index = 1,
+      }
+   end
+
    local index = storage.players[pindex].guns_menu.index
    index = index + 1
    if index == 4 then
@@ -530,12 +555,28 @@ function mod.guns_menu_right(pindex)
 end
 
 function mod.guns_menu_up_or_down(pindex)
+   -- Initialize guns_menu if it doesn't exist
+   if not storage.players[pindex].guns_menu then
+      storage.players[pindex].guns_menu = {
+         ammo_selected = false,
+         index = 1,
+      }
+   end
+
    storage.players[pindex].guns_menu.ammo_selected = not storage.players[pindex].guns_menu.ammo_selected
    game.get_player(pindex).play_sound({ path = "Inventory-Move" })
    mod.guns_menu_read_slot(pindex)
 end
 
 function mod.guns_menu_get_selected_slot(pindex)
+   -- Initialize guns_menu if it doesn't exist
+   if not storage.players[pindex].guns_menu then
+      storage.players[pindex].guns_menu = {
+         ammo_selected = false,
+         index = 1,
+      }
+   end
+
    local menu = storage.players[pindex].guns_menu
    local p = game.get_player(pindex)
    local gun_stack = p.get_inventory(defines.inventory.character_guns)[menu.index]
@@ -549,6 +590,15 @@ end
 
 function mod.guns_menu_read_slot(pindex, start_phrase_in)
    local start_phrase = start_phrase_in or ""
+
+   -- Initialize guns_menu if it doesn't exist
+   if not storage.players[pindex].guns_menu then
+      storage.players[pindex].guns_menu = {
+         ammo_selected = false,
+         index = 1,
+      }
+   end
+
    local menu = storage.players[pindex].guns_menu
    local p = game.get_player(pindex)
    local result = { "" }
@@ -602,6 +652,15 @@ end
 function mod.guns_menu_click_slot(pindex)
    local p = game.get_player(pindex)
    local hand = p.cursor_stack
+
+   -- Initialize guns_menu if it doesn't exist
+   if not storage.players[pindex].guns_menu then
+      storage.players[pindex].guns_menu = {
+         ammo_selected = false,
+         index = 1,
+      }
+   end
+
    local menu = storage.players[pindex].guns_menu
    local gun_stack = p.get_inventory(defines.inventory.character_guns)[menu.index]
    local ammo_stack = p.get_inventory(defines.inventory.character_ammo)[menu.index]

--- a/scripts/scanner/entrypoint.lua
+++ b/scripts/scanner/entrypoint.lua
@@ -112,11 +112,17 @@ local function do_refresh_after_sfx(pindex, direction_filter)
    -- scan refresh.
    local ps = player_state[pindex]
 
-   do
-      local cat = ps.scanner_cursor.category
+   -- Handle case where player state doesn't exist (e.g., old save)
+   if not ps then
       player_state[pindex] = new_player_state(pindex)
       ps = player_state[pindex]
-      ps.scanner_cursor.category = cat
+   end
+
+   do
+      local cat = ps.scanner_cursor and ps.scanner_cursor.category
+      player_state[pindex] = new_player_state(pindex)
+      ps = player_state[pindex]
+      if cat then ps.scanner_cursor.category = cat end
    end
 
    local player_obj = assert(game.get_player(pindex))


### PR DESCRIPTION
# Fix nil reference crashes in scanner and equipment systems

## Summary
This PR fixes two critical crashes that occur when loading saves created with older versions of FactorioAccess or when player state is not fully initialized.

## Issues Fixed

### 1. Scanner crash on refresh (line 116)
- **Error**: `attempt to index field 'scanner_cursor' (a nil value)`
- **Cause**: Loading saves where `player_state[pindex]` was never initialized
- **Fix**: Added nil check before accessing `scanner_cursor.category`

### 2. Equipment/guns menu crash (line 500)
- **Error**: `attempt to index field 'guns_menu' (a nil value)` when pressing R
- **Cause**: `storage.players[pindex].guns_menu` not initialized for existing saves
- **Fix**: Added defensive initialization in all 8 functions that access guns_menu

## Changes Made

### `scripts/scanner/entrypoint.lua`
- Added nil check for `player_state[pindex]` in `do_refresh_after_sfx()`
- Safely initializes player state if missing

### `scripts/equipment.lua`
- Added `guns_menu` initialization checks to:
  - `guns_menu_open()`
  - `guns_menu_left()`
  - `guns_menu_right()`
  - `guns_menu_up_or_down()`
  - `guns_menu_get_selected_slot()`
  - `guns_menu_read_slot()`
  - `guns_menu_click_slot()`

### `control.lua`
- Added nil check in coordinate announcement handler for guns menu

## Testing
✅ Scanner no longer crashes when pressing PAGE UP/DOWN with old saves
✅ Guns menu (R key) now opens successfully without crashes
✅ All gun navigation keys (WASD in guns menu) work without errors
✅ Tested with both fresh saves and saves from before these features existed

## Technical Details
Both issues stem from the same root cause: when loading saves created before certain features were added, the corresponding storage structures don't exist. The mod previously assumed these would always be present, leading to nil reference errors.

This PR adds defensive programming practices by checking for nil values and initializing missing structures with sensible defaults when needed.

## Backwards Compatibility
These changes maintain full backwards compatibility. Old saves will have the missing structures created on-demand when the relevant features are first accessed.